### PR TITLE
CompatController: Allow to mix old-style actions with new-style ones

### DIFF
--- a/src/Compat/CompatController.php
+++ b/src/Compat/CompatController.php
@@ -41,8 +41,6 @@ class CompatController extends Controller
     {
         parent::prepareInit();
 
-        unset($this->view->tabs);
-
         $this->params->shift('isIframe');
         $this->params->shift('showFullscreen');
         $this->params->shift('showCompact');
@@ -65,6 +63,7 @@ class CompatController extends Controller
         $this->tabs->setAttribute('id', $this->getRequest()->protectId('tabs'));
         $this->parts = [];
 
+        $this->view->tabs = $this->tabs;
         $this->controls->setTabs($this->tabs);
 
         ViewRenderer::inject();
@@ -276,14 +275,14 @@ class CompatController extends Controller
         if (empty($this->parts)) {
             if (! $this->content->isEmpty()) {
                 $this->document->prepend($this->content);
-            }
 
-            if (! $this->view->compact && ! $this->controls->isEmpty()) {
-                $this->document->prepend($this->controls);
-            }
+                if (! $this->view->compact && ! $this->controls->isEmpty()) {
+                    $this->document->prepend($this->controls);
+                }
 
-            if (! $this->footer->isEmpty()) {
-                $this->document->add($this->footer);
+                if (! $this->footer->isEmpty()) {
+                    $this->document->add($this->footer);
+                }
             }
         } else {
             $partSeparator = base64_encode(random_bytes(16));


### PR DESCRIPTION
This will now only render the controls and footer if there's any content.
This is based on the assumption that an action has to define explicit
content if it wants to show controls or a footer. Even if the content
is populated by Javascript, there's usually another container part of
the content and the content is not directly utilized as target.