### PR TITLE
Suggestions: Show column path in default if there's no label

### DIFF
--- a/src/Control/SearchBar/Suggestions.php
+++ b/src/Control/SearchBar/Suggestions.php
@@ -151,7 +151,7 @@ abstract class Suggestions extends BaseHtmlElement
 
                 $terms[] = [
                     'search'    => $child->getColumn(),
-                    'label'     => $child->metaData()->get('columnLabel'),
+                    'label'     => $child->metaData()->get('columnLabel') ?? $child->getColumn(),
                     'type'      => 'column'
                 ];
                 $terms[] = [


### PR DESCRIPTION
The column path is also in the search bar labels the default, so why not here as well? Otherwise nothing is shown: `Search for *test* in:`