### PR TITLE
CompatForm: Insert duplicate submit button when more than one is present

### DIFF
--- a/asset/css/primary-submit-btn-duplicate.less
+++ b/asset/css/primary-submit-btn-duplicate.less
@@ -1,0 +1,16 @@
+/**
+  Automatically set CSS class for duplicated submit buttons
+  used for implicit form submission that should be invisible
+  and not take up any space. `display: none` is not an option,
+  because at least Safari will then ignore the element completely
+  when submitting a form.
+ */
+.primary-submit-btn-duplicate {
+  border: 0;
+  height: 0;
+  margin: 0;
+  padding: 0;
+  visibility: hidden;
+  width: 0;
+  position: absolute;
+}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "ipl\\Tests\\Web\\": "tests"
+      "ipl\\Tests\\Web\\": "tests",
+      "ipl\\Tests\\Html\\": "vendor/ipl/html/tests"
     }
   },
   "require": {

--- a/src/Compat/CompatForm.php
+++ b/src/Compat/CompatForm.php
@@ -2,7 +2,11 @@
 
 namespace ipl\Web\Compat;
 
+use ipl\Html\Contract\FormSubmitElement;
 use ipl\Html\Form;
+use ipl\Html\FormElement\SubmitElement;
+use ipl\Html\HtmlDocument;
+use ipl\Html\HtmlString;
 use ipl\I18n\Translation;
 use ipl\Web\FormDecorator\IcingaFormDecorator;
 
@@ -11,6 +15,27 @@ class CompatForm extends Form
     use Translation;
 
     protected $defaultAttributes = ['class' => 'icinga-form icinga-controls'];
+
+    /**
+     * Render the content of the element to HTML
+     *
+     * A duplicate of the primary submit button is being prepended if there is more than one present
+     *
+     * @return string
+     */
+    public function renderContent(): string
+    {
+        if (count($this->submitElements) > 1) {
+            return (new HtmlDocument())
+                ->setHtmlContent(
+                    $this->duplicateSubmitButton($this->submitButton),
+                    new HtmlString(parent::renderContent())
+                )
+                ->render();
+        }
+
+        return parent::renderContent();
+    }
 
     public function hasDefaultElementDecorator()
     {
@@ -21,5 +46,21 @@ class CompatForm extends Form
         $this->setDefaultElementDecorator(new IcingaFormDecorator());
 
         return true;
+    }
+
+    /**
+     * Return a duplicate of the given submit button with the `class` attribute fixed to `primary-submit-btn-duplicate`
+     *
+     * @param FormSubmitElement $originalSubmitButton
+     *
+     * @return SubmitElement
+     */
+    public function duplicateSubmitButton(FormSubmitElement $originalSubmitButton): SubmitElement
+    {
+        $attributes = (clone $originalSubmitButton->getAttributes())
+            ->set('class', 'primary-submit-btn-duplicate');
+        $attributes->remove('id');
+
+        return new SubmitElement($originalSubmitButton->getName(), $attributes);
     }
 }


### PR DESCRIPTION
Creates a new `SubmitElement` from the primary submit button of the form with cloned Attributes from the given `FormSubmitElement`. The new submit button is always at the top of the form.
The element has a fixed `primary-submit-btn-duplicate` class, which hides to button, but not the functionality when submitting the form.