### PR TITLE
SearchBar: Fix that `getFilter()` returns an outdated filter

### DIFF
--- a/src/Control/SearchBar.php
+++ b/src/Control/SearchBar.php
@@ -214,6 +214,18 @@ class SearchBar extends Form
         return $id;
     }
 
+    public function populate($values)
+    {
+        if (array_key_exists($this->getSearchParameter(), (array) $values)) {
+            // If a filter is set, it must be reset in case new data arrives. The new data controls the filter,
+            // though if no data is sent, (populate() is only called if the form is sent) then the filter must
+            // be reset explicitly here to not keep the outdated filter.
+            $this->filter = Filter::all();
+        }
+
+        parent::populate($values);
+    }
+
     public function isValidEvent($event)
     {
         switch ($event) {


### PR DESCRIPTION
With the [recent changes](https://github.com/Icinga/ipl-html/pull/118) in ipl-html, `Form::validatePartial()` only validates elements with a value again. This results in the search bar not returning the filter transmitted by an autosubmit if the filter has been fully cleared by the user.