### PR TITLE
Add optional `$defaultSort` parameter for `SortControl::apply` method

### DIFF
--- a/src/Compat/CompatController.php
+++ b/src/Compat/CompatController.php
@@ -283,6 +283,7 @@ class CompatController extends Controller
      *
      * @param Query $query
      * @param array $columns Possible sort columns as sort string-label pairs
+     * @param ?array|string $defaultSort Optional default sort column
      *
      * @return SortControl
      */
@@ -292,7 +293,13 @@ class CompatController extends Controller
 
         $this->params->shift($sortControl->getSortParam());
 
-        return $sortControl->apply($query);
+        $defaultSort = null;
+
+        if (func_num_args() === 3) {
+            $defaultSort = func_get_args()[2];
+        }
+
+        return $sortControl->apply($query, $defaultSort);
     }
 
     /**

--- a/src/Control/SortControl.php
+++ b/src/Control/SortControl.php
@@ -169,12 +169,13 @@ class SortControl extends Form
      * Sort the given query according to the request
      *
      * @param Query $query
+     * @param ?array|string $defaultSort
      *
      * @return $this
      */
-    public function apply(Query $query)
+    public function apply(Query $query, $defaultSort = null)
     {
-        $default = (array) $query->getModel()->getDefaultSort();
+        $default = $defaultSort ?? (array) $query->getModel()->getDefaultSort();
         if (! empty($default)) {
             $this->setDefault(SortUtil::normalizeSortSpec($default));
         }


### PR DESCRIPTION
This gives an option to set the default sort of sort control other than the `ipl\Orm\Model`s default sort as default.