### PR TITLE
Properly validate user input in term inputs and filter inputs

### DIFF
--- a/src/Control/SearchBar/ValidatedTerm.php
+++ b/src/Control/SearchBar/ValidatedTerm.php
@@ -149,13 +149,13 @@ abstract class ValidatedTerm
      *
      * @return string
      */
-    public function getPattern(): string
+    public function getPattern(): ?string
     {
-        if ($this->pattern === null) {
-            return sprintf(self::DEFAULT_PATTERN, $this->getSearchValue());
+        if ($this->message === null) {
+            return null;
         }
 
-        return $this->pattern;
+        return $this->pattern ?? sprintf(self::DEFAULT_PATTERN, $this->getLabel() ?: $this->getSearchValue());
     }
 
     /**

--- a/src/FormElement/TermInput/RegisteredTerm.php
+++ b/src/FormElement/TermInput/RegisteredTerm.php
@@ -90,7 +90,7 @@ class RegisteredTerm implements Term
             return null;
         }
 
-        return $this->pattern ?? sprintf(Term::DEFAULT_CONSTRAINT, $this->getSearchValue());
+        return $this->pattern ?? sprintf(Term::DEFAULT_CONSTRAINT, $this->getLabel() ?? $this->getSearchValue());
     }
 
     /**


### PR DESCRIPTION
The validation api validates an input's value, and if a label exists for a given term, it's used as value instead of the search value. Hence the pattern should check for the label, not the search value in such a case.