### PR TITLE
TermInput.js: Encode and quote terms, not the other way round

### DIFF
--- a/asset/js/widget/TermInput.js
+++ b/asset/js/widget/TermInput.js
@@ -73,14 +73,15 @@ define(["../notjQuery", "BaseInput"], function ($, BaseInput) {
         termsToQueryString(terms) {
             let quoted = [];
             for (const termData of terms) {
-                if (termData.search.indexOf(this.separator) >= 0) {
-                    quoted.push({ ...termData, search: '"' + termData.search + '"' });
-                } else {
-                    quoted.push(termData);
+                let search = this.encodeTerm(termData).search;
+                if (search.indexOf(this.separator) >= 0) {
+                    search = '"' + termData.search + '"';
                 }
+
+                quoted.push(search);
             }
 
-            return super.termsToQueryString(quoted);
+            return quoted.join(this.separator).trim();
         }
 
         complete(input, data) {


### PR DESCRIPTION
Any separator which needs to be encoded, won't be detected and thus no unnecessary quoting happens. If, on the other hand, the quoting is necessary due to an unencoded separator, the quotes are not encoded, as the server doesn't expect or need this.