### PR TITLE
TermInput.js: Also accept new terms upon pushing Enter

### DIFF
--- a/asset/js/widget/TermInput.js
+++ b/asset/js/widget/TermInput.js
@@ -135,7 +135,7 @@ define(["../notjQuery", "BaseInput"], function ($, BaseInput) {
                 return;
             }
 
-            if (event.key !== this.separator) {
+            if (event.key !== this.separator && event.key !== 'Enter') {
                 return;
             }
 


### PR DESCRIPTION
It's now controlled. Previously it depended on whether Enter is able to submit the form or not. But a submit isn't required either.