### PR TITLE
SortControl: Apply the url's parameter if the form is not sent

### DIFF
--- a/src/Control/SortControl.php
+++ b/src/Control/SortControl.php
@@ -76,7 +76,7 @@ class SortControl extends Form
         $self = new static($normalized, Url::fromRequest());
 
         $self->on(self::ON_REQUEST, function (ServerRequestInterface $request) use ($self) {
-            if ($self->getMethod() === 'POST' && $request->getMethod() === 'GET') {
+            if (! $self->hasBeenSent()) {
                 // If the form is submitted by POST, handleRequest() won't access the URL, so we have to
                 if (($sort = $request->getQueryParams()[$self->getSortParam()] ?? null)) {
                     $self->populate([$self->getSortParam() => $sort]);


### PR DESCRIPTION
The previous condition only applied if the form's method was `POST` but not the request's. Essentially, if it was not being sent. Now it also applies if the form's method is `GET` but not the request's. (if another form is being sent)

fixes #199