### PR TITLE
css: Transfer icingadb related searchbar styles to default control layout

### DIFF
--- a/asset/css/compat.less
+++ b/asset/css/compat.less
@@ -86,14 +86,3 @@ form.icinga-form .control-group {
     }
   }
 }
-
-// SearchBar styles
-
-.icinga-module.module-icingadb .controls .search-bar .filter-input-area {
-  label {
-    &::after,
-    input {
-      padding: 0 .5em;
-    }
-  }
-}

--- a/asset/css/controls.less
+++ b/asset/css/controls.less
@@ -152,4 +152,13 @@
     // Suggestions should be kept at a distance from the bottom of the page
     margin-bottom: 2.5em;
   }
+
+  > .search-controls > .search-bar .filter-input-area {
+    label {
+      &::after,
+      input {
+        padding: 0 .5em;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Any view using the default controls layout should have a thin search bar. Just like Icinga DB Web.