### PR TITLE
BaseItemList: Emit events before and after adding the list item to the list

### DIFF
--- a/asset/css/list/list-item.less
+++ b/asset/css/list/list-item.less
@@ -33,6 +33,10 @@
       &:hover {
         color: @list-item-title-hover-color;
         text-decoration: none;
+
+        .subject {
+          color: @list-item-title-hover-color;
+        }
       }
     }
   }

--- a/src/Common/BaseItemList.php
+++ b/src/Common/BaseItemList.php
@@ -15,6 +15,12 @@ abstract class BaseItemList extends BaseHtmlElement
 {
     use BaseFilter;
 
+    /** @var string Emitted while assembling the list after adding each list item */
+    public const ON_ITEM_ADD = 'item-added';
+
+    /** @var string Emitted while assembling the list before adding each list item */
+    public const BEFORE_ITEM_ADD = 'before-item-add';
+
     /** @var array<string, mixed> */
     protected $baseAttributes = [
         'class'                         => ['item-list', 'default-layout'],
@@ -62,7 +68,9 @@ abstract class BaseItemList extends BaseHtmlElement
         foreach ($this->data as $data) {
             /** @var BaseListItem|BaseTableRowItem $item */
             $item = new $itemClass($data, $this);
+            $this->emit(self::BEFORE_ITEM_ADD, [$item, $data]);
             $this->addHtml($item);
+            $this->emit(self::ON_ITEM_ADD, [$item, $data]);
         }
 
         if ($this->isEmpty()) {


### PR DESCRIPTION
It would be helpful if lists could perform additional tasks before and after a list item is added to it. Hence the events `BEFORE_ITEM_ADD` and `ON_ITEM_ADD` would be desirable.