### PR TITLE
css: Use equal height for an icinga icon's `i` and `::before`

### DIFF
--- a/asset/css/icons-base.less
+++ b/asset/css/icons-base.less
@@ -1,8 +1,12 @@
 i.icon {
   vertical-align: middle; // Firefox will place icons weird otherwise
+  display: inline-block;
 
-  &:before {
-    display: inline-block;
+  font-style: normal;
+  line-height: 1;
+
+  &::before {
+    display: block;
     min-width: 1em;
     margin-right: .2em;
 


### PR DESCRIPTION
fixes #209