### PR TITLE
BaseTableRowItem: Use `column-content` as CSS class

### DIFF
--- a/asset/css/list/item-table.less
+++ b/asset/css/list/item-table.less
@@ -48,7 +48,7 @@ ul.item-table {
       margin-bottom: -.5em;
     }
 
-    .content {
+    .column-content {
       flex: 1 1 auto;
       width: 0;
 

--- a/src/Common/BaseTableRowItem.php
+++ b/src/Common/BaseTableRowItem.php
@@ -65,7 +65,7 @@ abstract class BaseTableRowItem extends BaseHtmlElement
             Attributes::create(['class' => 'col']),
             new HtmlElement(
                 'div',
-                Attributes::create(['class' => 'content']),
+                Attributes::create(['class' => 'column-content']),
                 ...Html::wantHtmlList($content)
             )
         );


### PR DESCRIPTION
`content` collides with a container's content and confuses Icinga Web's JS (<2.12.2) which applies `impact` to it, but doesn't remove it sometimes.