### PR TITLE
Fetch item class for each row of the data

### DIFF
--- a/src/Common/BaseItemList.php
+++ b/src/Common/BaseItemList.php
@@ -62,12 +62,24 @@ abstract class BaseItemList extends BaseHtmlElement
     {
     }
 
+    /**
+     * Create a list item for the given data
+     *
+     * @param object $data
+     *
+     * @return BaseListItem|BaseTableRowItem
+     */
+    protected function createListItem(object $data)
+    {
+        $className = $this->getItemClass();
+
+        return new $className($data, $this);
+    }
+
     protected function assemble(): void
     {
-        $itemClass = $this->getItemClass();
         foreach ($this->data as $data) {
-            /** @var BaseListItem|BaseTableRowItem $item */
-            $item = new $itemClass($data, $this);
+            $item = $this->createListItem($data);
             $this->emit(self::BEFORE_ITEM_ADD, [$item, $data]);
             $this->addHtml($item);
             $this->emit(self::ON_ITEM_ADD, [$item, $data]);


### PR DESCRIPTION
Currently, it is assumed that each list item in the list will be of same instance. Hence, calling `getItemClass()` method once in the `assemble()` method was sufficient to obtain the instance of the list item and build the entire list.

But if we want to build a list containing list items of different instances,  we would have to obtain the instance for each list item. For instance, the root problem list for dependencies contains host, service or redundancy group. Hence, the list item can be an instance of `HostListItem`, `ServiceListItem` or `RedundancyGroupListItem`.

In which case, it would require us to rewrite parent `assemble()` method, which is not desirable. To avoid this `createListItem()` method must be introduced, that will be responsible for creating the list item.

