### PR TITLE
item-list.less: Don't unset `margin-right` for `:only-child`

### DIFF
--- a/asset/css/list/item-list.less
+++ b/asset/css/list/item-list.less
@@ -69,7 +69,7 @@
         margin-left: 0;
       }
 
-      &:last-child {
+      &:last-child:not(:only-child) {
         margin-right: 0;
       }
     }


### PR DESCRIPTION
RedundancyGroupListItem's title contain only one element. In this his case, the margin-right should not be unset.

ref https://github.com/Icinga/icingadb-web/pull/1098