### PR TITLE
Display delete action when hovering over read-only term-input entries

### DIFF
--- a/asset/css/search-base.less
+++ b/asset/css/search-base.less
@@ -332,7 +332,7 @@ fieldset:disabled .term-input-area [data-drag-initiator] {
         top: 0;
         line-height: normal;
         padding: 0.5em;
-        cursor: pointer;
+        pointer-events: none;
 
         .remove-action-label {
           .text-ellipsis();

--- a/asset/css/search-base.less
+++ b/asset/css/search-base.less
@@ -75,6 +75,15 @@ fieldset:disabled .term-input-area [data-drag-initiator] {
   }
 }
 
+.remove-action {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: @search-term-remove-action-bg;
+  color: @search-term-remove-action-color;
+  .rounded-corners(0.25em);
+}
+
 .search-suggestions {
   background: var(--suggestions-bg, @suggestions-bg);
   color: var(--suggestions-color, @suggestions-color);
@@ -167,7 +176,7 @@ fieldset:disabled .term-input-area [data-drag-initiator] {
   label {
     position: relative;
     display: inline-block;
-    min-width: 2em;
+    min-width: 6em;
     height: 100%;
 
     &::after,
@@ -210,6 +219,11 @@ fieldset:disabled .term-input-area [data-drag-initiator] {
     label {
       margin-right: 1px;
     }
+  }
+
+  &.read-only [data-index] .remove-action {
+    line-height: 20/12;
+    padding: var(--term-padding-v) var(--term-padding-h);
   }
 }
 
@@ -281,7 +295,6 @@ fieldset:disabled .term-input-area [data-drag-initiator] {
       position: relative;
 
       input {
-        padding-left: 1.5em;
         text-align: center;
         cursor: pointer;
 
@@ -307,6 +320,24 @@ fieldset:disabled .term-input-area [data-drag-initiator] {
         z-index: 1;
         top: 85%;
         left: .5em;
+      }
+
+      .remove-action {
+        visibility: visible;
+        position: absolute;
+        width: 100%;
+        top: 0;
+        line-height: normal;
+        padding: 0.5em;
+        cursor: pointer;
+
+        .remove-action-label {
+          .text-ellipsis();
+        }
+      }
+
+      &:not(:hover) .remove-action {
+        visibility: hidden;
       }
     }
   }

--- a/asset/css/search-base.less
+++ b/asset/css/search-base.less
@@ -58,30 +58,33 @@ fieldset:disabled .term-input-area [data-drag-initiator] {
   cursor: not-allowed;
 }
 
-.invalid-reason {
-  padding: .25em;
-  .rounded-corners(.25em);
-  border: 1px solid black;
-  font-weight: bold;
-  background: var(--search-term-invalid-reason-bg, @search-term-invalid-reason-bg);
+.term-input-area {
+  .invalid-reason {
+    padding: .25em;
+    .rounded-corners(.25em);
+    border: 1px solid black;
+    font-weight: bold;
+    background: var(--search-term-invalid-reason-bg, @search-term-invalid-reason-bg);
 
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity 2s, visibility 2s;
-  &.visible {
-    opacity: 1;
-    visibility: visible;
-    transition: none;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 2s, visibility 2s;
+
+    &.visible {
+      opacity: 1;
+      visibility: visible;
+      transition: none;
+    }
   }
-}
 
-.remove-action {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: @search-term-remove-action-bg;
-  color: @search-term-remove-action-color;
-  .rounded-corners(0.25em);
+  .remove-action {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: @search-term-remove-action-bg;
+    color: @search-term-remove-action-color;
+    .rounded-corners(0.25em);
+  }
 }
 
 .search-suggestions {

--- a/asset/css/variables.less
+++ b/asset/css/variables.less
@@ -70,6 +70,8 @@
 @search-term-highlighted-bg: @base-primary-bg;
 @search-term-highlighted-color: @default-text-color-inverted;
 @search-term-drag-border-color: @base-gray;
+@search-term-remove-action-bg: @default-remove-bg;
+@search-term-remove-action-color: @default-remove-color;
 
 @search-condition-remove-bg: @state-critical;
 @search-condition-remove-color: @default-text-color-inverted;
@@ -170,6 +172,8 @@
     --search-term-highlighted-bg: var(--primary-button-bg);
     --search-term-highlighted-color: var(--default-text-color-inverted);
     --search-term-drag-border-color: var(--base-gray);
+    --search-term-remove-action-bg: var(--default-remove-bg);
+    --search-term-remove-action-color: var(--default-remove-color);
 
     --search-condition-remove-bg: var(--base-remove-bg);
     --search-condition-remove-color: var(--default-text-color-inverted);

--- a/asset/css/variables.less
+++ b/asset/css/variables.less
@@ -41,6 +41,10 @@
 @default-text-color-light: fade(@default-text-color, 75%);
 @default-text-color-inverted: @default-bg;
 @default-input-bg: #404d72;
+@default-remove-bg: @state-critical;
+@default-remove-color: @default-text-color-inverted;
+@default-delete-bg: @state-critical;
+@default-delete-color: @default-text-color-inverted;
 
 @state-ok: #44bb77;
 @state-up: @state-ok;
@@ -143,6 +147,10 @@
     --default-text-color-light: fade(#535353, 75%); // --default-text-color
     --default-text-color-inverted: #F5F9FA;
     --default-input-bg: #DEECF1;
+    --default-remove-bg: var(--base-remove-bg);
+    --default-remove-color: var(--default-text-color-inverted);
+    --default-delete-bg: var(--base-remove-bg);
+    --default-delete-color: var(--default-text-color-inverted);
 
     --primary-button-color: var(--default-text-color-inverted);
     --primary-button-bg: @primary-button-bg;

--- a/asset/js/widget/TermInput.js
+++ b/asset/js/widget/TermInput.js
@@ -188,7 +188,14 @@ define(["../notjQuery", "../vendor/Sortable", "BaseInput"], function ($, Sortabl
 
             if (this.readOnly) {
                 label.firstChild.readOnly = true;
-                label.appendChild($.render('<i class="icon fa-trash fa"></i>'));
+                label.appendChild(
+                    $.render(
+                        '<div class="remove-action">' +
+                            '<i class="icon fa-trash fa"></i>' +
+                            '<span class="remove-action-label">' + this.termContainer.getAttribute('remove-action-label') + '</span>' +
+                        '</div>'
+                    )
+                );
                 label.appendChild($.render('<span class="invalid-reason"></span>'));
             }
 

--- a/asset/js/widget/TermInput.js
+++ b/asset/js/widget/TermInput.js
@@ -192,7 +192,9 @@ define(["../notjQuery", "../vendor/Sortable", "BaseInput"], function ($, Sortabl
                     $.render(
                         '<div class="remove-action">' +
                             '<i class="icon fa-trash fa"></i>' +
-                            '<span class="remove-action-label">' + this.termContainer.getAttribute('remove-action-label') + '</span>' +
+                            '<span class="remove-action-label">' +
+                                this.termContainer.dataset.removeActionLabel +
+                            '</span>' +
                         '</div>'
                     )
                 );

--- a/src/FormElement/TermInput/TermContainer.php
+++ b/src/FormElement/TermInput/TermContainer.php
@@ -40,7 +40,7 @@ class TermContainer extends BaseHtmlElement
         if ($this->input->getReadOnly()) {
             $removeLabel = $this->translate('Remove');
             // bind remove translation to DOM, this allows the JS part to make use of it
-            $this->setAttribute('remove-action-label', $removeLabel);
+            $this->setAttribute('data-remove-action-label', $removeLabel);
         }
 
         foreach ($this->input->getTerms() as $i => $term) {

--- a/src/FormElement/TermInput/TermContainer.php
+++ b/src/FormElement/TermInput/TermContainer.php
@@ -5,11 +5,15 @@ namespace ipl\Web\FormElement\TermInput;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlElement;
+use ipl\Html\Text;
+use ipl\I18n\Translation;
 use ipl\Web\FormElement\TermInput;
 use ipl\Web\Widget\Icon;
 
 class TermContainer extends BaseHtmlElement
 {
+    use Translation;
+
     protected $tag = 'div';
 
     protected $defaultAttributes = ['class' => 'terms'];
@@ -33,6 +37,12 @@ class TermContainer extends BaseHtmlElement
 
     protected function assemble()
     {
+        if ($this->input->getReadOnly()) {
+            $removeLabel = $this->translate('Remove');
+            // bind remove translation to DOM, this allows the JS part to make use of it
+            $this->setAttribute('remove-action-label', $removeLabel);
+        }
+
         foreach ($this->input->getTerms() as $i => $term) {
             $value = $term->getLabel() ?: $term->getSearchValue();
 
@@ -57,7 +67,16 @@ class TermContainer extends BaseHtmlElement
             );
             if ($this->input->getReadOnly()) {
                 $label->addHtml(
-                    new Icon('trash'),
+                    new HtmlElement(
+                        'div',
+                        Attributes::create(['class' => 'remove-action']),
+                        new Icon('trash'),
+                        new HtmlElement(
+                            'span',
+                            Attributes::create(['class' => 'remove-action-label']),
+                            new Text($removeLabel)
+                        )
+                    ),
                     new HtmlElement('span', Attributes::create(['class' => 'invalid-reason']))
                 );
             }


### PR DESCRIPTION
This PR changes the way by which the user gets hinted about the possibility to remove an entry out of a read-only list of term-input values.

Resolves: https://github.com/Icinga/ipl-web/issues/243