### PR TITLE
Introduce new item list/header layout implementation

### DIFF
--- a/asset/css/item-layout.less
+++ b/asset/css/item-layout.less
@@ -1,0 +1,154 @@
+// Layout
+
+.item-layout {
+  // Note that mode specific rules are as strict as possible to avoid conflicts with nested layouts.
+  // Consider an item which contains another item in a different layout mode. Coincidentally, this is
+  // already the case in Icinga DB Web with the last comment flyout.
+
+  .flowing-content(@layout) when (@layout = "default") {
+    & {
+      display: inline-flex;
+      align-items: baseline;
+      white-space: nowrap;
+      min-width: 0;
+      column-gap: .28125em; // calculated &nbsp; width
+
+      > .ellipsize, > .subject { // .subject is compat only, Icinga DB Web used it thoroughly
+        .text-ellipsis();
+      }
+    }
+  }
+  .flowing-content(@layout) when (@layout = 'detailed') {
+    word-break: break-word;
+    -webkit-hyphens: auto;
+    -ms-hyphens: auto;
+    hyphens: auto;
+
+    > * + * {
+      margin-left: .28125em; // calculated &nbsp; width
+    }
+  }
+
+  display: flex;
+
+  .visual {
+    display: flex;
+    flex-direction: column;
+
+    width: auto;
+    padding: .25em 0;
+    margin-right: 1em;
+  }
+
+  .main {
+    flex: 1 1 auto;
+    padding: .25em 0;
+    width: 0;
+  }
+
+  header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+  &.minimal-item-layout > .main > header {
+    max-width: 100%;
+  }
+
+  .caption {
+    p {
+      display: inline-block;
+    }
+
+    img {
+      max-height: 1em;
+    }
+  }
+  &.default-item-layout > .main > .caption {
+    height: 3em;
+    text-overflow: ellipsis;
+    overflow: hidden;
+
+    .line-clamp();
+  }
+  &.minimal-item-layout > .main > header > .caption {
+    flex: 1 1 auto;
+    height: 1.5em;
+    width: 0;
+
+    &:not(:empty) {
+      margin-right: 1em;
+    }
+
+    .text-ellipsis();
+  }
+  &.detailed-item-layout > .main > .caption {
+    display: block;
+    height: auto;
+    overflow: hidden;
+    max-height: 7.5em; /* 5 lines */
+    position: relative;
+
+    .line-clamp(4);
+  }
+
+  footer {
+    display: flex;
+    justify-content: space-between;
+
+    padding-top: .5em;
+  }
+
+  .title {
+    margin-right: 1em;
+  }
+  &.default-item-layout > .main > header > .title {
+    .flowing-content("default");
+  }
+  &.detailed-item-layout > .main > header > .title {
+    .flowing-content("detailed");
+  }
+
+  &.default-item-layout > .main > header > .extended-info {
+    .flowing-content("default");
+  }
+  &.detailed-item-layout > .main > header > .extended-info {
+    .flowing-content("detailed");
+  }
+}
+
+// Style
+
+.item-layout {
+  color: @default-text-color-light;
+
+  .caption {
+    i {
+      opacity: 0.8;
+    }
+
+    a {
+      color: @default-text-color;
+    }
+  }
+
+  .title {
+    .subject {
+      color: @default-text-color;
+    }
+
+    a {
+      color: @default-text-color;
+      font-weight: bold;
+
+      &:hover {
+        color: @link-hover-color;
+        text-decoration: none;
+
+        .subject {
+          color: @link-hover-color;
+        }
+      }
+    }
+  }
+}

--- a/asset/css/list/item-list.less
+++ b/asset/css/list/item-list.less
@@ -83,3 +83,14 @@
 .controls .list-item:not(:last-child) {
   margin-bottom: .5em;
 }
+
+:not(.dashboard) > .container > .content:has(> .item-list), // compat only, for Icinga Web
+.content:has(> .item-list) {
+  padding-left: 0;
+  padding-right: 0;
+
+  > .item-list > .list-item {
+    padding-left: 1em;
+    padding-right: 1em;
+  }
+}

--- a/asset/css/list/item-list.less
+++ b/asset/css/list/item-list.less
@@ -10,73 +10,8 @@
   margin: 0;
   padding: 0;
 
-  .list-item {
-    display: flex;
-
-    .main {
-      flex: 1 1 auto;
-      padding: .5em 0;
-      width: 0;
-      margin-left: .5em;
-    }
-
-    .visual {
-      display: flex;
-      align-items: center;
-      flex-direction: column;
-    }
-
-    .caption {
-      height: 3em;
-      text-overflow: ellipsis;
-      overflow: hidden;
-
-      .line-clamp();
-
-      img {
-        max-height: 1em;
-      }
-    }
-
-    header {
-      display: flex;
-      align-items: flex-start;
-      justify-content: space-between;
-    }
-
-    footer {
-      display: flex;
-      justify-content: space-between;
-    }
-  }
-
   > .empty-state-bar {
     margin: 0 1em;
-  }
-}
-
-.item-list.default-layout .list-item {
-  .title {
-    display: inline-flex;
-    align-items: baseline;
-    white-space: nowrap;
-    min-width: 0;
-
-    > * {
-      margin: 0 .28125em; // 0 calculated &nbsp; width
-
-      &:first-child {
-        margin-left: 0;
-      }
-
-      &:last-child {
-        margin-right: 0;
-      }
-    }
-
-    .subject {
-      .text-ellipsis();
-    }
   }
 }
 

--- a/asset/css/list/list-item.less
+++ b/asset/css/list/list-item.less
@@ -1,48 +1,12 @@
 // Style
 
 .list-item {
-  color: @default-text-color-light;
-
   &:not(:first-child) > .main {
     border-top: 1px solid @list-item-separation-bg;
   }
 
   &:not(:first-child) .visual {
     margin-top: 1px;
-  }
-
-  .caption {
-    i {
-      opacity: 0.8;
-    }
-
-    a {
-      color: @default-text-color;
-    }
-  }
-
-  .title {
-    .subject {
-      color: @default-text-color;
-    }
-
-    a {
-      color: @default-text-color;
-      font-weight: bold;
-
-      &:hover {
-        color: @list-item-title-hover-color;
-        text-decoration: none;
-
-        .subject {
-          color: @list-item-title-hover-color;
-        }
-      }
-    }
-  }
-
-  footer {
-    padding-top: .5em;
   }
 }
 
@@ -56,34 +20,10 @@
 
 // Layout
 
-.list-item {
+.list-item.item-layout {
+  .main,
   .visual {
-    padding: .5em 0;
-    width: 2.5em;
-  }
-
-  .caption {
-    p {
-      display: inline-block;
-    }
-  }
-
-  .title {
-    margin-right: 1em;
-
-    p {
-      margin: 0;
-    }
-  }
-
-  time {
-    white-space: nowrap;
-  }
-
-  footer {
-    > * {
-      font-size: .857em;
-      line-height: 1.5*.857em;
-    }
+    padding-top: .5em;
+    padding-bottom: .5em;
   }
 }

--- a/asset/css/variables.less
+++ b/asset/css/variables.less
@@ -58,6 +58,7 @@
 @primary-button-color: @default-text-color-inverted;
 @primary-button-bg: @base-primary-bg;
 @primary-button-hover-bg: @base-primary-dark;
+@link-hover-color: @base-primary-color;
 
 @search-term-bg: @base-gray;
 @search-term-color: @default-text-color-inverted;
@@ -132,7 +133,7 @@
 @empty-state-color: @base-gray-semilight;
 @empty-state-bar-bg: @base-gray-lighter;
 
-@list-item-title-hover-color: @base-primary-color;
+@list-item-title-hover-color: @link-hover-color;
 @list-item-separation-bg: @base-gray-light;
 
 @iplWebLightRules: {
@@ -157,6 +158,7 @@
     --primary-button-color: var(--default-text-color-inverted);
     --primary-button-bg: @primary-button-bg;
     --primary-button-hover-bg: @primary-button-hover-bg;
+    --link-hover-color: var(--base-primary-color);
 
     --searchbar-bg: var(--default-input-bg);
     --searchbar-scrollbar-bg: var(--base-gray-light);
@@ -226,7 +228,7 @@
     --empty-state-color: var(--base-gray-semilight);
     --empty-state-bar-bg: var(--base-gray-lighter);
 
-    --list-item-title-hover-color: var(--base-primary-color);
+    --list-item-title-hover-color: var(--link-hover-color);
     --list-item-separation-bg: var(--base-gray-light);
   }
 };

--- a/src/Common/BaseItemList.php
+++ b/src/Common/BaseItemList.php
@@ -7,9 +7,12 @@ use ipl\Html\BaseHtmlElement;
 use ipl\Orm\ResultSet;
 use ipl\Stdlib\BaseFilter;
 use ipl\Web\Widget\EmptyStateBar;
+use ipl\Web\Widget\ItemList;
 
 /**
  * Base class for item lists
+ *
+ * @deprecated Use {@see ItemList} instead
  */
 abstract class BaseItemList extends BaseHtmlElement
 {

--- a/src/Common/BaseListItem.php
+++ b/src/Common/BaseListItem.php
@@ -5,14 +5,17 @@ namespace ipl\Web\Common;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlElement;
+use ipl\Web\Widget\ItemList;
 
 /**
  * Base class for list items
+ *
+ * @deprecated Use a {@see ItemList} with a dedicated {@see ItemRenderer} instead.
  */
 abstract class BaseListItem extends BaseHtmlElement
 {
     /** @var array<string, mixed> */
-    protected $baseAttributes = ['class' => 'list-item'];
+    protected $baseAttributes = ['class' => ['list-item', 'item-layout', 'default-item-layout']];
 
     /** @var object The associated list item */
     protected $item;

--- a/src/Common/BaseOrderedItemList.php
+++ b/src/Common/BaseOrderedItemList.php
@@ -6,6 +6,7 @@ use ipl\Web\Widget\EmptyStateBar;
 
 /**
  * @method BaseOrderedListItem getItemClass()
+ * @deprecated Use your own implementation instead
  */
 abstract class BaseOrderedItemList extends BaseItemList
 {

--- a/src/Common/BaseOrderedListItem.php
+++ b/src/Common/BaseOrderedListItem.php
@@ -4,6 +4,7 @@ namespace ipl\Web\Common;
 
 use LogicException;
 
+/** @deprecated Use your own implementation instead */
 abstract class BaseOrderedListItem extends BaseListItem
 {
     /** @var ?int This element's position */

--- a/src/Common/ItemRenderer.php
+++ b/src/Common/ItemRenderer.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace ipl\Web\Common;
+
+use ipl\Html\Attributes;
+use ipl\Html\HtmlDocument;
+
+/**
+ * Interface for item renderers
+ *
+ * @template Item
+ */
+interface ItemRenderer
+{
+    /**
+     * Assemble the attributes for an item
+     *
+     * @param Item $item The item to render
+     * @param Attributes $attributes
+     * @param string $layout The name of the layout
+     *
+     * @return void
+     */
+    public function assembleAttributes($item, Attributes $attributes, string $layout): void;
+
+    /**
+     * Assemble a visual representation of an item
+     *
+     * @param Item $item The item to render
+     * @param HtmlDocument $visual The container to add the result to
+     * @param string $layout The name of the layout
+     *
+     * @return void
+     */
+    public function assembleVisual($item, HtmlDocument $visual, string $layout): void;
+
+    /**
+     * Assemble a caption to describe an item
+     *
+     * @param Item $item The item to render
+     * @param HtmlDocument $caption The container to add the result to
+     * @param string $layout The name of the layout
+     *
+     * @return void
+     */
+    public function assembleCaption($item, HtmlDocument $caption, string $layout): void;
+
+    /**
+     * Assemble a footer with additional information for an item
+     *
+     * @param Item $item The item to render
+     * @param HtmlDocument $footer The container to add the result to
+     * @param string $layout The name of the layout
+     *
+     * @return void
+     */
+    public function assembleFooter($item, HtmlDocument $footer, string $layout): void;
+
+    /**
+     * Assemble a title for an item
+     *
+     * @param Item $item The item to render
+     * @param HtmlDocument $title The container to add the result to
+     * @param string $layout The name of the layout
+     *
+     * @return void
+     */
+    public function assembleTitle($item, HtmlDocument $title, string $layout): void;
+
+    /**
+     * Assemble extended information for an item
+     *
+     * @param Item $item The item to render
+     * @param HtmlDocument $info The container to add the result to
+     * @param string $layout The name of the layout
+     *
+     * @return void
+     */
+    public function assembleExtendedInfo($item, HtmlDocument $info, string $layout): void;
+
+    /**
+     * Assemble a custom section for an item
+     *
+     * @param Item $item The item to render
+     * @param string $name The identifier of the section
+     * @param HtmlDocument $element The container to add the result to
+     * @param string $layout The name of the layout
+     *
+     * @return bool Whether to add the section to the layout
+     */
+    public function assemble($item, string $name, HtmlDocument $element, string $layout): bool;
+}

--- a/src/Layout/DetailedItemLayout.php
+++ b/src/Layout/DetailedItemLayout.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ipl\Web\Layout;
+
+use ipl\Html\Attributes;
+use ipl\Html\HtmlDocument;
+
+class DetailedItemLayout extends ItemLayout
+{
+    public const NAME = 'detailed';
+
+    public function createAttributes(Attributes $attributes): void
+    {
+        parent::createAttributes($attributes);
+
+        $attributes->get('class')
+            ->removeValue('default-item-layout')
+            ->addValue('detailed-item-layout');
+    }
+
+    protected function assembleMain(HtmlDocument $container): void
+    {
+        $this->registerHeader($container);
+        $this->registerCaption($container);
+        $this->registerFooter($container);
+    }
+}

--- a/src/Layout/HeaderItemLayout.php
+++ b/src/Layout/HeaderItemLayout.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ipl\Web\Layout;
+
+use ipl\Html\Attributes;
+
+class HeaderItemLayout extends MinimalItemLayout
+{
+    public const NAME = 'header';
+
+    public function createAttributes(Attributes $attributes): void
+    {
+        parent::createAttributes($attributes);
+
+        $attributes->get('class')->addValue('header-item-layout');
+    }
+}

--- a/src/Layout/ItemLayout.php
+++ b/src/Layout/ItemLayout.php
@@ -1,0 +1,478 @@
+<?php
+
+namespace ipl\Web\Layout;
+
+use ipl\Html\Attributes;
+use ipl\Html\HtmlDocument;
+use ipl\Html\HtmlElement;
+use ipl\Web\Common\ItemRenderer;
+
+/**
+ * Layout for items
+ *
+ * @phpstan-type _SECTION1 = static::VISUAL|static::MAIN|static::HEADER|static::FOOTER
+ * @phpstan-type SECTION = _SECTION1|static::CAPTION|static::TITLE|static::EXTENDED_INFO
+ * @template Item
+ */
+class ItemLayout extends HtmlDocument
+{
+    /** The name of this layout */
+    public const NAME = 'common';
+
+    /** Identifier for the section containing an item's visual representation */
+    public const VISUAL = 'visual';
+
+    /** Identifier for the section containing an item's main content */
+    public const MAIN = 'main';
+
+    /** Identifier for the section containing an item's header */
+    public const HEADER = 'header';
+
+    /** Identifier for the section containing an item's footer */
+    public const FOOTER = 'footer';
+
+    /** Identifier for the section containing an item's caption */
+    public const CAPTION = 'caption';
+
+    /** Identifier for the section containing an item's title */
+    public const TITLE = 'title';
+
+    /** Identifier for the section containing an item's extended information */
+    public const EXTENDED_INFO = 'extended-info';
+
+    /** @var Item */
+    protected $item;
+
+    /** @var ItemRenderer */
+    protected $renderer;
+
+    /** @var array<SECTION, string> */
+    protected $before = [];
+
+    /** @var array<SECTION, string> */
+    protected $after = [];
+
+    /**
+     * Create a new layout for items
+     *
+     * @param Item $item The item to render
+     * @param ItemRenderer<Item> $renderer The renderer used to assemble the layout's content
+     */
+    public function __construct($item, ItemRenderer $renderer)
+    {
+        $this->item = $item;
+        $this->renderer = $renderer;
+    }
+
+    /**
+     * Get the name of this layout
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return static::NAME;
+    }
+
+    /**
+     * Create attributes for this layout
+     *
+     * @param Attributes $attributes
+     *
+     * @return void
+     */
+    protected function createAttributes(Attributes $attributes): void
+    {
+        $attributes->get('class')->addValue(['item-layout', 'default-item-layout']);
+    }
+
+    /**
+     * Get attributes to apply to the container the layout is added to
+     *
+     * @return Attributes
+     */
+    public function getAttributes(): Attributes
+    {
+        $attributes = new Attributes();
+        $this->createAttributes($attributes);
+        $this->renderer->assembleAttributes($this->item, $attributes, $this->getName());
+
+        return $attributes;
+    }
+
+    /**
+     * Create a container for the visual representation of the item
+     *
+     * @return HtmlDocument
+     */
+    protected function createVisual(): HtmlDocument
+    {
+        return new HtmlElement('div', Attributes::create(['class' => static::VISUAL]));
+    }
+
+    /**
+     * Assemble the visual representation of the item in the given container
+     *
+     * @return void
+     */
+    protected function assembleVisual(HtmlDocument $container)
+    {
+        $this->renderer->assembleVisual($this->item, $container, $this->getName());
+    }
+
+    /**
+     * Create, assemble and register the visual representation of the item
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function registerVisual(HtmlDocument $container): void
+    {
+        $visual = $this->createVisual();
+
+        $this->createBefore(static::VISUAL, $container);
+
+        $this->assembleVisual($visual);
+        if ($visual->isEmpty()) {
+            return;
+        }
+
+        $container->addHtml($visual);
+
+        $this->createAfter(static::VISUAL, $container);
+    }
+
+    /**
+     * Create a container for the main content of the item
+     *
+     * @return HtmlDocument
+     */
+    protected function createMain(): HtmlDocument
+    {
+        return new HtmlElement('div', Attributes::create(['class' => static::MAIN]));
+    }
+
+    /**
+     * Assemble the main content of the item in the given container
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function assembleMain(HtmlDocument $container): void
+    {
+        $this->registerHeader($container);
+        $this->registerCaption($container);
+    }
+
+    /**
+     * Create, assemble and register the main content of the item
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function registerMain(HtmlDocument $container): void
+    {
+        $main = $this->createMain();
+
+        $this->createBefore(static::MAIN, $container);
+
+        $this->assembleMain($main);
+
+        $container->addHtml($main);
+
+        $this->createAfter(static::MAIN, $container);
+    }
+
+    /**
+     * Create a container for the header of the item
+     *
+     * @return HtmlDocument
+     */
+    protected function createHeader(): HtmlDocument
+    {
+        return new HtmlElement('header');
+    }
+
+    /**
+     * Assemble the header of the item in the given container
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function assembleHeader(HtmlDocument $container): void
+    {
+        $this->registerTitle($container);
+        $this->registerExtendedInfo($container);
+    }
+
+    /**
+     * Create, assemble and register the header of the item
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function registerHeader(HtmlDocument $container): void
+    {
+        $header = $this->createHeader();
+
+        $this->createBefore(static::HEADER, $container);
+
+        $this->assembleHeader($header);
+
+        $container->addHtml($header);
+
+        $this->createAfter(static::HEADER, $container);
+    }
+
+    /**
+     * Create a container for the footer of the item
+     *
+     * @return HtmlDocument
+     */
+    protected function createFooter(): HtmlDocument
+    {
+        return new HtmlElement('footer');
+    }
+
+    /**
+     * Assemble the footer of the item in the given container
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function assembleFooter(HtmlDocument $container): void
+    {
+        $this->renderer->assembleFooter($this->item, $container, $this->getName());
+    }
+
+    /**
+     * Create, assemble and register the footer of the item
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function registerFooter(HtmlDocument $container): void
+    {
+        $footer = $this->createFooter();
+
+        $this->createBefore(static::FOOTER, $container);
+
+        $this->assembleFooter($footer);
+        if ($footer->isEmpty()) {
+            return;
+        }
+
+        $container->addHtml($footer);
+
+        $this->createAfter(static::FOOTER, $container);
+    }
+
+    /**
+     * Create a container for the caption of the item
+     *
+     * @return HtmlDocument
+     */
+    protected function createCaption(): HtmlDocument
+    {
+        return new HtmlElement('section', Attributes::create(['class' => static::CAPTION]));
+    }
+
+    /**
+     * Assemble the caption of the item in the given container
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function assembleCaption(HtmlDocument $container): void
+    {
+        $this->renderer->assembleCaption($this->item, $container, $this->getName());
+    }
+
+    /**
+     * Create, assemble and register the caption of the item
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function registerCaption(HtmlDocument $container): void
+    {
+        $caption = $this->createCaption();
+
+        $this->createBefore(static::CAPTION, $container);
+
+        $this->assembleCaption($caption);
+
+        $container->addHtml($caption);
+
+        $this->createAfter(static::CAPTION, $container);
+    }
+
+    /**
+     * Create a container for the title of the item
+     *
+     * @return HtmlDocument
+     */
+    protected function createTitle(): HtmlDocument
+    {
+        return new HtmlElement('div', Attributes::create(['class' => static::TITLE]));
+    }
+
+    /**
+     * Assemble the title of the item in the given container
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function assembleTitle(HtmlDocument $container): void
+    {
+        $this->renderer->assembleTitle($this->item, $container, $this->getName());
+    }
+
+    /**
+     * Create, assemble and register the title of the item
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function registerTitle(HtmlDocument $container): void
+    {
+        $title = $this->createTitle();
+
+        $this->createBefore(static::TITLE, $container);
+
+        $this->assembleTitle($title);
+
+        $container->addHtml($title);
+
+        $this->createAfter(static::TITLE, $container);
+    }
+
+    /**
+     * Create a container for the extended information of the item
+     *
+     * @return HtmlDocument
+     */
+    protected function createExtendedInfo(): HtmlDocument
+    {
+        return new HtmlElement('div', Attributes::create(['class' => static::EXTENDED_INFO]));
+    }
+
+    /**
+     * Assemble the extended information of the item in the given container
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function assembleExtendedInfo(HtmlDocument $container): void
+    {
+        $this->renderer->assembleExtendedInfo($this->item, $container, $this->getName());
+    }
+
+    /**
+     * Create, assemble and register the extended information of the item
+     *
+     * @param HtmlDocument $container
+     *
+     * @return void
+     */
+    protected function registerExtendedInfo(HtmlDocument $container): void
+    {
+        $info = $this->createExtendedInfo();
+
+        $this->createBefore(static::EXTENDED_INFO, $container);
+
+        $this->assembleExtendedInfo($info);
+        if ($info->isEmpty()) {
+            return;
+        }
+
+        $container->addHtml($info);
+
+        $this->createAfter(static::EXTENDED_INFO, $container);
+    }
+
+    /**
+     * Render a custom section before the given one
+     *
+     * @param SECTION $section Identifier of the target section
+     * @param string $customSection Identifier for the custom section
+     *
+     * @return void
+     */
+    public function before(string $section, string $customSection): void
+    {
+        $this->before[$section] = $customSection;
+    }
+
+    /**
+     * Add a custom section before the given one
+     *
+     * @param SECTION $section Identifier of the target section
+     * @param HtmlDocument $container The container to add the custom section to
+     *
+     * @return void
+     */
+    protected function createBefore(string $section, HtmlDocument $container): void
+    {
+        if (isset($this->before[$section])) {
+            $customSection = new HtmlElement('div', Attributes::create(['class' => $this->before[$section]]));
+            if ($this->renderer->assemble($this->item, $this->before[$section], $customSection, $this->getName())) {
+                $container->addHtml($customSection);
+            }
+        }
+    }
+
+    /**
+     * Render a custom section after the given one
+     *
+     * @param SECTION $section Identifier of the target section
+     * @param string $customSection Identifier for the custom section
+     *
+     * @return void
+     */
+    public function after(string $section, string $customSection): void
+    {
+        $this->after[$section] = $customSection;
+    }
+
+    /**
+     * Add a custom section after the given one
+     *
+     * @param SECTION $section Identifier of the target section
+     * @param HtmlDocument $container The container to add the custom section to
+     *
+     * @return void
+     */
+    protected function createAfter(string $section, HtmlDocument $container): void
+    {
+        if (isset($this->after[$section])) {
+            $customSection = new HtmlElement('div', Attributes::create(['class' => $this->after[$section]]));
+            if ($this->renderer->assemble($this->item, $this->after[$section], $customSection, $this->getName())) {
+                $container->addHtml($customSection);
+            }
+        }
+    }
+
+    /**
+     * Assemble the layout
+     *
+     * @return void
+     */
+    protected function assemble(): void
+    {
+        $this->registerVisual($this);
+        $this->registerMain($this);
+    }
+}

--- a/src/Layout/MinimalItemLayout.php
+++ b/src/Layout/MinimalItemLayout.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ipl\Web\Layout;
+
+use ipl\Html\Attributes;
+use ipl\Html\HtmlDocument;
+
+class MinimalItemLayout extends ItemLayout
+{
+    public const NAME = 'minimal';
+
+    public function createAttributes(Attributes $attributes): void
+    {
+        parent::createAttributes($attributes);
+
+        $attributes->get('class')->addValue('minimal-item-layout');
+    }
+
+    protected function assembleMain(HtmlDocument $container): void
+    {
+        $this->registerHeader($container);
+    }
+
+    protected function assembleHeader(HtmlDocument $container): void
+    {
+        $this->registerTitle($container);
+        $this->registerCaption($container);
+        $this->registerExtendedInfo($container);
+    }
+}

--- a/src/Widget/ItemList.php
+++ b/src/Widget/ItemList.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace ipl\Web\Widget;
+
+use InvalidArgumentException;
+use ipl\Html\BaseHtmlElement;
+use ipl\Orm\ResultSet;
+use ipl\Web\Common\ItemRenderer;
+use ipl\Web\Layout\ItemLayout;
+
+/**
+ * ItemList
+ *
+ * @template Result of object
+ * @template Item of object = Result
+ */
+class ItemList extends BaseHtmlElement
+{
+    /** @var string Emitted while assembling the list after adding each list item */
+    public const ON_ITEM_ADD = 'item-added';
+
+    /** @var string Emitted while assembling the list before adding each list item */
+    public const BEFORE_ITEM_ADD = 'before-item-add';
+
+    /** @var ResultSet|iterable<Result> */
+    protected $data;
+
+    /** @var ItemRenderer|callable */
+    protected $itemRenderer;
+
+    /** @var string */
+    private $itemLayoutClass = ItemLayout::class;
+
+    /** @var ?string Message to show if the list is empty */
+    protected $emptyStateMessage;
+
+    /** @var array<string, mixed> */
+    protected $baseAttributes = [
+        'class'                         => 'item-list',
+        'data-base-target'              => '_next',
+        'data-pdfexport-page-breaks-at' => '.list-item'
+    ];
+
+    protected $tag = 'ul';
+
+    /**
+     * Create a new item list
+     *
+     * @param ResultSet|iterable<Result> $data
+     * @param ItemRenderer<Item>|callable $itemRenderer If a callable is passed,
+     *                                                  it must accept an item as first argument
+     */
+    public function __construct($data, $itemRenderer)
+    {
+        if (! is_iterable($data)) {
+            throw new InvalidArgumentException('Data must be an array or an instance of Traversable');
+        }
+
+        $this->data = $data;
+        $this->itemRenderer = $itemRenderer;
+
+        $this->addAttributes($this->baseAttributes);
+
+        $this->init();
+    }
+
+    /**
+     * Initialize the item list
+     *
+     * If you want to adjust the item list after construction, override this method.
+     */
+    protected function init(): void
+    {
+    }
+
+    /**
+     * Set the layout class for the items
+     *
+     * @param string $class Must be an instance of the previously set item layout class
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException If the class is not a subclass of {@see ItemLayout}
+     */
+    public function setItemLayoutClass(string $class): self
+    {
+        if ($class !== $this->itemLayoutClass && ! is_subclass_of($class, $this->itemLayoutClass)) {
+            throw new InvalidArgumentException("Class $class must be a subclass of " . $this->itemLayoutClass);
+        }
+
+        $this->itemLayoutClass = $class;
+
+        return $this;
+    }
+
+    /**
+     * Get the layout for the given item
+     *
+     * @param Item $item
+     *
+     * @return ItemLayout
+     */
+    public function getItemLayout($item): ItemLayout
+    {
+        return new $this->itemLayoutClass($item, $this->getItemRenderer($item));
+    }
+
+    /**
+     * Get message to show if the list is empty
+     *
+     * @return string
+     */
+    public function getEmptyStateMessage(): string
+    {
+        if ($this->emptyStateMessage === null) {
+            return t('No items found.');
+        }
+
+        return $this->emptyStateMessage;
+    }
+
+    /**
+     * Set message to show if the list is empty
+     *
+     * @param string $message
+     *
+     * @return $this
+     */
+    public function setEmptyStateMessage(string $message): self
+    {
+        $this->emptyStateMessage = $message;
+
+        return $this;
+    }
+
+    /**
+     * Get renderer for the given item
+     *
+     * @param Item $item
+     *
+     * @return ItemRenderer<Item>
+     */
+    protected function getItemRenderer($item): ItemRenderer
+    {
+        if (is_callable($this->itemRenderer)) {
+            return call_user_func($this->itemRenderer, $item);
+        } elseif (is_string($this->itemRenderer)) {
+            $this->itemRenderer = new $this->itemRenderer();
+        }
+
+        return $this->itemRenderer;
+    }
+
+    /**
+     * Create a list item for the given data
+     *
+     * @param Result $data
+     *
+     * @return ListItem<Item>
+     */
+    protected function createListItem(object $data)
+    {
+        return new ListItem($data, $this);
+    }
+
+    protected function assemble(): void
+    {
+        /** @var Result $data */
+        foreach ($this->data as $data) {
+            $item = $this->createListItem($data);
+            $this->emit(self::BEFORE_ITEM_ADD, [$item, $data]);
+            $this->addHtml($item);
+            $this->emit(self::ON_ITEM_ADD, [$item, $data]);
+        }
+
+        if ($this->isEmpty()) {
+            $this->setTag('div');
+            $this->addHtml(new EmptyStateBar($this->getEmptyStateMessage()));
+        }
+    }
+}

--- a/src/Widget/ListItem.php
+++ b/src/Widget/ListItem.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ipl\Web\Widget;
+
+use ipl\Html\BaseHtmlElement;
+
+/**
+ * List item
+ *
+ * It is rarely necessary to extend this class. Instead, you should create a new layout class that extends
+ * {@see ItemLayout} and pass it to the {@see ItemList} instance.
+ *
+ * @template Item
+ */
+class ListItem extends BaseHtmlElement
+{
+    /** @var Item The associated list item */
+    protected $item;
+
+    /** @var ItemList<Item> The list where the item is part of */
+    protected $list;
+
+    protected $tag = 'li';
+
+    protected $defaultAttributes = ['class' => 'list-item'];
+
+    /**
+     * Create a new list item
+     *
+     * @param Item $item
+     * @param ItemList<Item> $list
+     */
+    public function __construct($item, ItemList $list)
+    {
+        $this->item = $item;
+        $this->list = $list;
+    }
+
+    protected function assemble()
+    {
+        $layout = $this->list->getItemLayout($this->item);
+
+        $this->addAttributes($layout->getAttributes());
+        $this->addHtml($layout);
+    }
+}


### PR DESCRIPTION
Represents mostly what was already part of Icinga DB Web in the form of view modes. The important change is that what was previously list layout, is now just item layout.

Allowing the re-use of the same implementation of any given layout in a list or list-like container, but also in any other, e.g. a detail header.

Just implement a renderer for a particular item type and couple it with the desired layout. Add the result to your list item, header, flyout, whatever and… you're done!