### PR TITLE
TermInput: Keep original minimum width of terms

### DIFF
--- a/asset/css/search-base.less
+++ b/asset/css/search-base.less
@@ -78,9 +78,6 @@ fieldset:disabled .term-input-area [data-drag-initiator] {
   }
 
   .remove-action {
-    display: flex;
-    justify-content: center;
-    align-items: center;
     background: @search-term-remove-action-bg;
     color: @search-term-remove-action-color;
     .rounded-corners(0.25em);
@@ -179,7 +176,7 @@ fieldset:disabled .term-input-area [data-drag-initiator] {
   label {
     position: relative;
     display: inline-block;
-    min-width: 6em;
+    min-width: 2em;
     height: 100%;
 
     &::after,
@@ -326,17 +323,29 @@ fieldset:disabled .term-input-area [data-drag-initiator] {
       }
 
       .remove-action {
+        display: flex;
+        align-items: center;
         visibility: visible;
         position: absolute;
         width: 100%;
         top: 0;
         line-height: normal;
         padding: 0.5em;
-        pointer-events: none;
+        cursor: pointer;
+
+        i.icon {
+          margin-left: auto;
+        }
 
         .remove-action-label {
+          margin-right: auto;
           .text-ellipsis();
         }
+      }
+
+      input:invalid ~ .remove-action,
+      input.invalid ~ .remove-action {
+        pointer-events: none;
       }
 
       &:not(:hover) .remove-action {

--- a/asset/js/widget/TermInput.js
+++ b/asset/js/widget/TermInput.js
@@ -187,14 +187,13 @@ define(["../notjQuery", "../vendor/Sortable", "BaseInput"], function ($, Sortabl
             const label = super.renderTerm(termData, termIndex);
 
             if (this.readOnly) {
+                const removeLabel = this.termContainer.dataset.removeActionLabel;
                 label.firstChild.readOnly = true;
                 label.appendChild(
                     $.render(
-                        '<div class="remove-action">' +
+                        `<div class="remove-action" title="${ removeLabel }">` +
                             '<i class="icon fa-trash fa"></i>' +
-                            '<span class="remove-action-label">' +
-                                this.termContainer.dataset.removeActionLabel +
-                            '</span>' +
+                            `<span class="remove-action-label">${ removeLabel }</span>` +
                         '</div>'
                     )
                 );

--- a/src/FormElement/TermInput/TermContainer.php
+++ b/src/FormElement/TermInput/TermContainer.php
@@ -69,7 +69,7 @@ class TermContainer extends BaseHtmlElement
                 $label->addHtml(
                     new HtmlElement(
                         'div',
-                        Attributes::create(['class' => 'remove-action']),
+                        Attributes::create(['class' => 'remove-action', 'title' => $removeLabel]),
                         new Icon('trash'),
                         new HtmlElement(
                             'span',


### PR DESCRIPTION
The remove label is now a title which allows terms to be as narrow as possible again.

justify-content which was previously used to center the label's contents cannot be used anymore though. It has the effect of pushing overflowing content
also to the left, which causes the icon to not be
centered at the minimum width. Plain old, but working, auto margins are the solution here.

fixes #256