### PR TITLE
Provide a way to go back to the first page in case the current page is empty

### DIFF
--- a/src/Control/PaginationControl.php
+++ b/src/Control/PaginationControl.php
@@ -470,12 +470,14 @@ class PaginationControl extends BaseHtmlElement
             'title' => t('Go to page …')
         ]);
 
-        if ($currentPageNumber === 1 || $currentPageNumber === $this->getPageCount()) {
+        $pageCount = $this->getPageCount();
+
+        if ($currentPageNumber === 1 || $currentPageNumber === $pageCount) {
             $select->add(Html::tag('option', ['disabled' => '', 'selected' => ''], '…'));
         }
 
-        if (2 <= $this->getPageCount() - 1) {
-            foreach (range(2, $this->getPageCount() - 1) as $page) {
+        if (2 <= $pageCount - 1) {
+            foreach (range(2, $pageCount - 1) as $page) {
                 $option = Html::tag('option', [
                     'value' => $page
                 ], $page);
@@ -488,7 +490,7 @@ class PaginationControl extends BaseHtmlElement
             }
         }
 
-        if ($currentPageNumber > $this->getPageCount()) {
+        if ($currentPageNumber > $pageCount) {
             $select->add(Html::tag('option', [
                 'value' => $currentPageNumber,
                 'selected' => '',

--- a/src/Control/PaginationControl.php
+++ b/src/Control/PaginationControl.php
@@ -474,16 +474,18 @@ class PaginationControl extends BaseHtmlElement
             $select->add(Html::tag('option', ['disabled' => '', 'selected' => ''], '…'));
         }
 
-        foreach (range(2, $this->getPageCount() - 1) as $page) {
-            $option = Html::tag('option', [
-                'value' => $page
-            ], $page);
+        if (2 <= $this->getPageCount() - 1) {
+            foreach (range(2, $this->getPageCount() - 1) as $page) {
+                $option = Html::tag('option', [
+                    'value' => $page
+                ], $page);
 
-            if ($page == $currentPageNumber) {
-                $option->addAttributes(['selected' => '']);
+                if ($page == $currentPageNumber) {
+                    $option->addAttributes(['selected' => '']);
+                }
+
+                $select->add($option);
             }
-
-            $select->add($option);
         }
 
         if ($currentPageNumber > $this->getPageCount()) {

--- a/src/Control/PaginationControl.php
+++ b/src/Control/PaginationControl.php
@@ -486,6 +486,14 @@ class PaginationControl extends BaseHtmlElement
             $select->add($option);
         }
 
+        if ($currentPageNumber > $this->getPageCount()) {
+            $select->add(Html::tag('option', [
+                'value' => $currentPageNumber,
+                'selected' => '',
+                'disabled' => ''
+            ], $currentPageNumber));
+        }
+
         $form->add($select);
 
         $pageSelectorItem = Html::tag('li', $form);


### PR DESCRIPTION
By following a link a user got from someone, the resulting entries might be fewer than previously and hence the list will also be empty.

If there is only a single page, the control didn't provide any option to switch to it until now.

Now a simple link allows to clear the page parameter.

fixes #267