### PR TITLE
Remove 'display: block' from state ball icons

### DIFF
--- a/asset/css/balls.less
+++ b/asset/css/balls.less
@@ -140,7 +140,6 @@
 
   i.icon {
     text-align: center;
-    display: block;
 
     &::before {
       margin-right: 0;


### PR DESCRIPTION
Remove 'display: block' from state ball icons to avoid icons moving to the top.

Refs https://github.com/Icinga/icingadb-web/issues/1042