### PR TITLE
ItemList: Don't convert `null` to Html

### DIFF
--- a/src/Widget/ItemList.php
+++ b/src/Widget/ItemList.php
@@ -128,13 +128,17 @@ class ItemList extends BaseHtmlElement
     /**
      * Set message to show if the list is empty
      *
-     * @param mixed $message
+     * @param mixed $message If empty, the default message is used
      *
      * @return $this
      */
     public function setEmptyStateMessage(mixed $message): self
     {
-        $this->emptyStateMessage = Html::wantHtml($message);
+        if (empty($message)) {
+            $this->emptyStateMessage = null;
+        } else {
+            $this->emptyStateMessage = Html::wantHtml($message);
+        }
 
         return $this;
     }


### PR DESCRIPTION
<img width="473" alt="Screenshot 2025-05-09 at 12 57 08" src="https://github.com/user-attachments/assets/3c97b027-a42b-44dc-8b6d-f6acd2bdd602" />

Since there are no comments, `$paginationControl->getEmptyStateMessage()` returns `null` and passes this to `ObjectList`, which converts the null to a `ipl/Html/Text` instance, resulting in a missing default message.