### PR TITLE
Compatibility enhancements

### DIFF
--- a/asset/css/compat.less
+++ b/asset/css/compat.less
@@ -86,3 +86,42 @@ form.icinga-form .control-group {
     }
   }
 }
+
+.module-icingadb {
+  // Icinga DB Web (legacy) table header layout (e.g. in group details)
+  > .controls {
+    > .table-row {
+      display: flex;
+      gap: .5em;
+
+      > .col.title {
+        margin-right: auto;
+      }
+    }
+  }
+
+  // Icinga DB Web (legacy) object grid layout
+  > .content > .item-table.group-grid:has(.col.title) {
+    grid-template-columns: repeat(auto-fit, 15em) !important;
+
+    > .group-grid-cell {
+      display: revert;
+
+      &::before, &::after {
+        display: none !important;
+      }
+
+      > .col.title {
+        border: none;
+
+        > .column-content {
+          overflow: hidden;
+
+          > * {
+            .text-ellipsis();
+          }
+        }
+      }
+    }
+  }
+}

--- a/asset/css/list/item-table.less
+++ b/asset/css/list/item-table.less
@@ -89,6 +89,16 @@ ul.item-table {
       }
     }
 
+    // This is for the legacy layout only
+    // TODO: Drop this together with BaseTableRowItem
+    .col.title:has(> .visual) {
+      display: flex;
+
+      > .visual {
+        padding-right: .5em;
+      }
+    }
+
     &:not(:last-of-type) {
       .col {
         border-bottom: 1px solid @list-item-separation-bg;

--- a/src/Common/BaseTableRowItem.php
+++ b/src/Common/BaseTableRowItem.php
@@ -13,7 +13,7 @@ use ipl\Web\Widget\ItemTable;
 abstract class BaseTableRowItem extends BaseHtmlElement
 {
     /** @var array<string, mixed> */
-    protected $baseAttributes = ['class' => 'table-row'];
+    protected $baseAttributes = ['class' => ['table-row', 'item-layout', 'default-item-layout']];
 
     /** @var object The associated list item */
     protected $item;


### PR DESCRIPTION
Followup of #253.

* Users of `\ipl\Web\Common\BaseTableRowItem` got weird results in the UI with it, which is fixed here.
* Icinga DB Web uses a custom layout that is based on the old item table layout. Quick fixes are included here.