### PR TITLE
Limit default item layout caption to one line

### DIFF
--- a/asset/css/item-layout.less
+++ b/asset/css/item-layout.less
@@ -67,11 +67,9 @@
     }
   }
   &.default-item-layout > .main > .caption {
-    height: 3em;
-    text-overflow: ellipsis;
-    overflow: hidden;
+    height: 1.5em;
 
-    .line-clamp();
+    .text-ellipsis();
   }
   &.minimal-item-layout > .main > header > .caption {
     flex: 1 1 auto;


### PR DESCRIPTION
Reduce the caption from **two** lines to **one** line in the default item layout.