### PR TITLE
Use empty state for item lists

### DIFF
--- a/asset/css/empty-state.less
+++ b/asset/css/empty-state.less
@@ -8,4 +8,5 @@
 
   .rounded-corners();
   background-color: @empty-state-bar-bg;
+  color: @default-text-color;
 }

--- a/asset/css/list/item-list.less
+++ b/asset/css/list/item-list.less
@@ -19,7 +19,6 @@
   margin-bottom: .5em;
 }
 
-:not(.dashboard) > .container > .content:has(> .item-list), // compat only, for Icinga Web
 .content:has(> .item-list) {
   padding-left: 0;
   padding-right: 0;

--- a/asset/css/list/item-list.less
+++ b/asset/css/list/item-list.less
@@ -4,6 +4,10 @@
   list-style-type: none;
 }
 
+.content:has(> .item-list) > .item-list > .empty-state {
+  .empty-state-bar();
+}
+
 // Layout
 
 .item-list {

--- a/asset/css/list/item-table.less
+++ b/asset/css/list/item-table.less
@@ -32,7 +32,6 @@ ul.item-table {
   }
 }
 
-:not(.dashboard) > .container > .content:has(> .item-table), // compat only, for Icinga Web
 .content:has(> .item-table) {
   padding-left: 0;
   padding-right: 0;

--- a/asset/css/list/item-table.less
+++ b/asset/css/list/item-table.less
@@ -4,6 +4,10 @@ ul.item-table {
   list-style-type: none;
 }
 
+.content:has(> .item-table) > .item-table > .empty-state {
+  .empty-state-bar();
+}
+
 // Layout
 
 ul.item-table {

--- a/src/Widget/ItemList.php
+++ b/src/Widget/ItemList.php
@@ -185,7 +185,7 @@ class ItemList extends BaseHtmlElement
 
         if ($this->isEmpty()) {
             $this->setTag('div');
-            $this->addHtml(new EmptyStateBar($this->getEmptyStateMessage()));
+            $this->addHtml(new EmptyState($this->getEmptyStateMessage()));
         }
     }
 }


### PR DESCRIPTION
Use `EmptyState` instead of`EmptyStateBar` in `ItemList` but keep rendering it as as `EmptyStateBar` if the list is the **main content**.