### PR TITLE
Clicking submit button should submit the form with term input

### DIFF
--- a/asset/js/widget/TermInput.js
+++ b/asset/js/widget/TermInput.js
@@ -319,7 +319,12 @@ define(["../notjQuery", "../vendor/Sortable", "BaseInput"], function ($, Sortabl
         }
 
         onButtonClick(event) {
-            if (! this.hasSyntaxError()) {
+            // Exchange terms only when an Enter key is pressed while not in the term input.
+            // If the pointerType is not empty, the click event is triggered by clicking the Submit button in the form,
+            // and the default submit event should not be prevented.
+            // The below solution does not work if the click event is triggered by pressing Space while on the Submit button.
+            // In which case the Submit button needs to be clicked again to trigger the form submission.
+            if (! this.hasSyntaxError() && event.pointerType === '') {
                 let addedTerms = this.exchangeTerm();
                 if (Object.keys(addedTerms).length) {
                     this.togglePlaceholder();


### PR DESCRIPTION
Previously, the first click of submit button in a form with with the term input was triggering an auto submit, instead of submitting the form. This fix resolves it.

**Before**:

https://github.com/user-attachments/assets/de4964ef-c7cb-47f1-8986-e17db8066f07



**After**:


https://github.com/user-attachments/assets/64bce31f-231e-43d2-802d-9b571713144c


