### PR TITLE
item-list: Apply h-margin to empty-state in full-width layout

### DIFF
--- a/asset/css/list/item-list.less
+++ b/asset/css/list/item-list.less
@@ -32,4 +32,7 @@
     padding-left: 1em;
     padding-right: 1em;
   }
+  > .item-list > .empty-state {
+    margin: 0 1em;
+  }
 }


### PR DESCRIPTION
fixes #288