### PR TITLE
CsrfCounterMeasure: accept Sec-Fetch-Site header, if available, instead of token

### DIFF
--- a/src/Common/CsrfCounterMeasure.php
+++ b/src/Common/CsrfCounterMeasure.php
@@ -26,6 +26,12 @@ trait CsrfCounterMeasure
             'ignore'        => true,
             'required'      => true,
             'validators'    => ['Callback' => function ($token) use ($uniqueId, $hashAlgo) {
+                switch ($_SERVER['HTTP_SEC_FETCH_SITE'] ?? '') {
+                    case 'same-origin': // same scheme, host and port
+                    case 'none': // a user-originated operation
+                        return true;
+                }
+
                 if (empty($token) || strpos($token, '|') === false) {
                     throw new Error('Invalid CSRF token provided');
                 }

--- a/src/Common/CsrfCounterMeasure.php
+++ b/src/Common/CsrfCounterMeasure.php
@@ -41,14 +41,35 @@ trait CsrfCounterMeasure
     /**
      * Create a form element to countermeasure CSRF attacks
      *
+     * If the {@see requestIsSafe()} check concludes the request is safe, returns a dummy element that accepts any
+     * value. If it concludes the request is unsafe, throws an {@see Error}. If the check is inconclusive (legacy
+     * browser), creates a token-based CSRF element validated against $uniqueId.
+     *
      * @param string $uniqueId A unique ID that persists through different requests
      *
      * @return FormElement
+     *
+     * @throws Error If {@see requestIsSafe()} returns false
      *
      * @deprecated Use {@see addCsrfCounterMeasure()} instead
      */
     protected function createCsrfCounterMeasure($uniqueId)
     {
+        $requestIsSafe = $this->requestIsSafe();
+
+        if ($requestIsSafe !== null) {
+            if (! $requestIsSafe) {
+                throw new Error('Rejecting cross-site request');
+            }
+
+            return new HiddenElement('CSRFToken', [
+                'ignore'     => true,
+                'validators' => ['Callback' => function () {
+                    return true;
+                }]
+            ]);
+        }
+
         $hashAlgo = in_array('sha3-256', hash_algos(), true) ? 'sha3-256' : 'sha256';
 
         $seed = random_bytes(16);
@@ -107,5 +128,24 @@ trait CsrfCounterMeasure
         }
 
         $this->addElement($this->createCsrfCounterMeasure($uniqueId ?? $this->csrfCounterMeasureId));
+    }
+
+    /**
+     * Get whether the request is safe from CSRF based on the Sec-Fetch-Site header
+     *
+     * Returns true if the header indicates a same-origin request or a user-originated operation (e.g. typing a URL),
+     * both of which cannot be forged by a cross-site attacker. Returns null if the header is absent,
+     * in which case a CSRF token must be validated. False indicates a cross-site request.
+     *
+     * @return ?bool
+     */
+    protected function requestIsSafe(): ?bool
+    {
+        return match ($_SERVER['HTTP_SEC_FETCH_SITE'] ?? null) {
+            'same-origin' => true, // same scheme, host and port
+            'none'        => true, // a user-originated operation
+            null          => null, // legacy browser without Sec-Fetch-Site support
+            default       => false,
+        };
     }
 }

--- a/tests/Common/CsrfCounterMeasureTest.php
+++ b/tests/Common/CsrfCounterMeasureTest.php
@@ -8,14 +8,28 @@ use ipl\Html\Form;
 use ipl\Html\FormElement\HiddenElement;
 use ipl\Tests\Web\TestCase;
 use ipl\Web\Common\CsrfCounterMeasure;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CsrfCounterMeasureTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        unset($_SERVER['HTTP_SEC_FETCH_SITE']);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($_SERVER['HTTP_SEC_FETCH_SITE']);
+    }
+
     public function testTokenCreation()
     {
         $token = $this->createElement();
 
         $this->assertInstanceOf(HiddenElement::class, $token);
+        $this->assertNotCount(0, $token->getValidators(), 'Token element must have at least one validator');
         $this->assertMatchesRegularExpression(
             '/ value="[^"]+\|[^"]+"/',
             (string) $token,
@@ -57,6 +71,47 @@ class CsrfCounterMeasureTest extends TestCase
         $token->isValid();
     }
 
+    public static function safeHeaderValueProvider(): array
+    {
+        return [
+            'same-origin' => ['same-origin'],
+            'none'        => ['none'],
+        ];
+    }
+
+    public function testAddThrowsForCrossSiteRequest(): void
+    {
+        $_SERVER['HTTP_SEC_FETCH_SITE'] = 'cross-site';
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Rejecting cross-site request');
+
+        $this->makeForm()->ensureAssembled();
+    }
+
+    #[DataProvider('safeHeaderValueProvider')]
+    public function testCreateReturnsDummyElementForSafeRequest(string $headerValue): void
+    {
+        $_SERVER['HTTP_SEC_FETCH_SITE'] = $headerValue;
+
+        $element = $this->makeForm()->callCreate('uniqueId');
+
+        $this->assertInstanceOf(HiddenElement::class, $element);
+        $this->assertNotCount(0, $element->getValidators(), 'Dummy element must have at least one validator');
+        $element->setValue('garbage');
+        $this->assertTrue($element->isValid(), 'Dummy element should accept any value without validation');
+    }
+
+    public function testCreateThrowsForCrossSiteRequest(): void
+    {
+        $_SERVER['HTTP_SEC_FETCH_SITE'] = 'cross-site';
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Rejecting cross-site request');
+
+        $this->makeForm()->callCreate('uniqueId');
+    }
+
     private function createElement(): FormElement
     {
         $form = new class extends Form {
@@ -71,5 +126,22 @@ class CsrfCounterMeasureTest extends TestCase
         return $form->setCsrfCounterMeasureId('uniqueId')
             ->ensureAssembled()
             ->getElement('CSRFToken');
+    }
+
+    private function makeForm()
+    {
+        return new class extends Form {
+            use CsrfCounterMeasure;
+
+            public function callCreate(string $id): FormElement
+            {
+                return $this->createCsrfCounterMeasure($id);
+            }
+
+            protected function assemble(): void
+            {
+                $this->addCsrfCounterMeasure('uniqueId');
+            }
+        };
     }
 }


### PR DESCRIPTION
This is especially useful if the session and token change suddenly, e.g. due to mod_auth_openidc.

refs https://github.com/Icinga/icingaweb2/issues/5224