### PR TITLE
Align title and caption text in minimal layout

### DIFF
--- a/asset/css/item-layout.less
+++ b/asset/css/item-layout.less
@@ -50,11 +50,12 @@
 
   header {
     display: flex;
-    align-items: flex-start;
+    align-items: baseline;
     justify-content: space-between;
   }
   &.minimal-item-layout > .main > header {
     max-width: 100%;
+    height: 1.5em;
   }
 
   .caption {

--- a/asset/css/item-layout.less
+++ b/asset/css/item-layout.less
@@ -52,15 +52,12 @@
     display: flex;
     align-items: baseline;
     justify-content: space-between;
-  }
-  &.minimal-item-layout > .main > header {
-    max-width: 100%;
-    height: 1.5em;
+
+    > .extended-info {
+      flex-shrink: 0;
+    }
   }
 
-  &.default-item-layout > .main > header {
-    height: 1.5em;
-  }
   .caption {
     p {
       display: inline-block;
@@ -69,29 +66,6 @@
     img {
       max-height: 1em;
     }
-  }
-  &.default-item-layout > .main > .caption {
-    height: 1.5em;
-
-    .text-ellipsis();
-  }
-  &.minimal-item-layout > .main > header > .caption {
-    flex: 1 1 auto;
-    height: 1.5em;
-    width: 0;
-
-    &:not(:empty) {
-      margin-right: 1em;
-    }
-
-    .text-ellipsis();
-  }
-  &.detailed-item-layout > .main > .caption {
-    display: block;
-    overflow: hidden;
-    position: relative;
-
-    .line-clamp(5);
   }
 
   footer {
@@ -104,24 +78,65 @@
   .title {
     margin-right: 1em;
   }
-  &.default-item-layout > .main > header > .title {
-    .flowing-content("default");
-  }
-  &.detailed-item-layout > .main > header > .title {
-    .flowing-content("detailed");
 
-    word-break: break-word;
-    hyphens: auto;
+  &.minimal-item-layout > .main > header {
+    max-width: 100%;
+    height: 1.5em;
+
+    > .caption {
+      flex: 1 1 auto;
+      height: 1.5em;
+      width: 0;
+
+      &:not(:empty) {
+        margin-right: 1em;
+      }
+
+      .text-ellipsis();
+    }
   }
 
-  header > .extended-info {
-    flex-shrink: 0;
+  &.default-item-layout > .main {
+    > header {
+      height: 1.5em;
+
+      > .title {
+        .flowing-content("default");
+      }
+
+      > .extended-info {
+        .flowing-content("default");
+      }
+    }
+
+    > .caption {
+      height: 1.5em;
+
+      .text-ellipsis();
+    }
   }
-  &.default-item-layout > .main > header > .extended-info {
-    .flowing-content("default");
-  }
-  &.detailed-item-layout > .main > header > .extended-info {
-    .flowing-content("detailed");
+
+  &.detailed-item-layout > .main {
+    > header {
+      > .title {
+        .flowing-content("detailed");
+
+        word-break: break-word;
+        hyphens: auto;
+      }
+
+      > .extended-info {
+        .flowing-content("detailed");
+      }
+    }
+
+    > .caption {
+      display: block;
+      overflow: hidden;
+      position: relative;
+
+      .line-clamp(5);
+    }
   }
 }
 

--- a/asset/css/item-layout.less
+++ b/asset/css/item-layout.less
@@ -58,6 +58,9 @@
     height: 1.5em;
   }
 
+  &.default-item-layout > .main > header {
+    height: 1.5em;
+  }
   .caption {
     p {
       display: inline-block;


### PR DESCRIPTION
## Problem
In the minimal view mode in item lists, the check output is not properly aligned vertically with the remaining text, it's baseline is slightly too high. This is because the header is a **flexbox** with `align-items: flex-start`. Setting `align-items: baseline` did increase the total `height` of the header from `18px` to `19px`. This is not what we want and would affect the control layout in the detail area of an object.

## Solution
To solve this we have to set the header's height to fixed `1.5em`. The `align-items: baseline` now aligns the texts without increasing the `height`.

Fixes https://github.com/Icinga/icingadb-web/issues/785