### PR TITLE
CsrfCounterMeasure: Allow external control

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      phpunit-version: 8.5
+      phpunit-version: 9.5
 
     strategy:
       fail-fast: false

--- a/src/Common/CsrfCounterMeasure.php
+++ b/src/Common/CsrfCounterMeasure.php
@@ -8,12 +8,44 @@ use ipl\Html\FormElement\HiddenElement;
 
 trait CsrfCounterMeasure
 {
+    /** @var ?string The ID of the CSRF form element */
+    private ?string $csrfCounterMeasureId = null;
+
+    /** @var bool Whether to actually add the CSRF element to the form */
+    private bool $csrfCounterMeasureEnabled = true;
+
+    /**
+     * Set the ID for the CSRF form element
+     *
+     * @param string $id A unique ID that persists through different requests
+     *
+     * @return $this
+     */
+    public function setCsrfCounterMeasureId(string $id): static
+    {
+        $this->csrfCounterMeasureId = $id;
+
+        return $this;
+    }
+
+    /**
+     * Disable the CSRF form element
+     *
+     * @return void
+     */
+    public function disableCsrfCounterMeasure(): void
+    {
+        $this->csrfCounterMeasureEnabled = false;
+    }
+
     /**
      * Create a form element to countermeasure CSRF attacks
      *
      * @param string $uniqueId A unique ID that persists through different requests
      *
      * @return FormElement
+     *
+     * @deprecated Use {@see addCsrfCounterMeasure()} instead
      */
     protected function createCsrfCounterMeasure($uniqueId)
     {
@@ -52,5 +84,28 @@ trait CsrfCounterMeasure
         });
 
         return $element;
+    }
+
+    /**
+     * Add the CSRF form element to this form
+     *
+     * Does nothing if disabled via {@see disableCsrfCounterMeasure()}.
+     * Unless passed as argument, requires a unique ID to be set via {@see setCsrfCounterMeasureId()}.
+     *
+     * @param ?string $uniqueId A unique ID that persists through different requests
+     *
+     * @return void
+     */
+    protected function addCsrfCounterMeasure(?string $uniqueId = null): void
+    {
+        if (! $this->csrfCounterMeasureEnabled) {
+            return;
+        }
+
+        if ($uniqueId === null && $this->csrfCounterMeasureId === null) {
+            throw new Error('No CSRF counter measure ID set');
+        }
+
+        $this->addElement($this->createCsrfCounterMeasure($uniqueId ?? $this->csrfCounterMeasureId));
     }
 }

--- a/tests/Common/CsrfCounterMeasureTest.php
+++ b/tests/Common/CsrfCounterMeasureTest.php
@@ -15,7 +15,7 @@ class CsrfCounterMeasureTest extends TestCase
         $token = $this->createElement();
 
         $this->assertInstanceOf(HiddenElement::class, $token);
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '/ value="[^"]+\|[^"]+"/',
             (string) $token,
             'The value is not rendered or does not contain a seed and a hash'
@@ -59,11 +59,16 @@ class CsrfCounterMeasureTest extends TestCase
     private function createElement(): FormElement
     {
         $form = new class extends Form {
-            use CsrfCounterMeasure {
-                createCsrfCounterMeasure as public;
+            use CsrfCounterMeasure;
+
+            protected function assemble()
+            {
+                $this->addCsrfCounterMeasure();
             }
         };
 
-        return $form->createCsrfCounterMeasure('uniqueId');
+        return $form->setCsrfCounterMeasureId('uniqueId')
+            ->ensureAssembled()
+            ->getElement('CSRFToken');
     }
 }


### PR DESCRIPTION
Allows to set the id using a setter, avoiding the need to access the session inside a form for example. A controller can now set the id. The same goes for deciding whether a token is required or not, which is necessary in unit tests, where it is not.

`createCsrfCounterMeasure()` has now been deprecated in favor of `addCsrfCounterMeasure()` since no element can be returned if disabled and 99% of all usages immediately add the *created* element to the form anyway.