### PR TITLE
SortControl: Do not check form transmission on request anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": ">=8.2",
     "ext-json": "*",
     "psr/http-message": "^1.1",
-    "ipl/html": ">=0.8.0",
+    "ipl/html": ">=0.9.0",
     "ipl/i18n": ">=0.2.0",
     "ipl/orm": ">=0.5.2",
     "ipl/scheduler": ">=0.1.0",

--- a/src/Control/SortControl.php
+++ b/src/Control/SortControl.php
@@ -68,11 +68,9 @@ class SortControl extends Form
         $self = new static($normalized);
 
         $self->on(self::ON_REQUEST, function (ServerRequestInterface $request) use ($self) {
-            if (! $self->hasBeenSent()) {
-                // If the form is submitted by POST, handleRequest() won't access the URL, so we have to
-                if (($sort = $request->getQueryParams()[$self->getSortParam()] ?? null)) {
-                    $self->populate([$self->getSortParam() => $sort]);
-                }
+            // If the form is submitted by POST, handleRequest() won't access the URL, so we have to
+            if (($sort = $request->getQueryParams()[$self->getSortParam()] ?? null)) {
+                $self->populate([$self->getSortParam() => $sort]);
             }
         });
 


### PR DESCRIPTION
The event is not being triggered anymore if the form has been sent.

Requires https://github.com/Icinga/ipl-html/pull/153