### PR TITLE
item-layout.less: Don't show empty `.caption` container in minimal-layout

### DIFF
--- a/asset/css/item-layout.less
+++ b/asset/css/item-layout.less
@@ -87,9 +87,10 @@
       flex: 1 1 auto;
       height: 1.5em;
       width: 0;
+      margin-right: 1em;
 
-      &:not(:empty) {
-        margin-right: 1em;
+      &:empty {
+        display: none; // not for Common/detailed, as it would not take up any height, making the list items appear smaller.
       }
 
       .text-ellipsis();


### PR DESCRIPTION
When the `.caption` is empty, the `<header>` items are not properly centered.
<img width="535" height="288" alt="Screenshot 2025-11-14 at 15 38 52" src="https://github.com/user-attachments/assets/e434ee41-01f3-459d-95b1-5d79dffba47b" />
