### PR TITLE
Introduce Callout

### DIFF
--- a/asset/css/callout.less
+++ b/asset/css/callout.less
@@ -5,7 +5,7 @@
   column-gap: 1em;
 
   width: fit-content;
-  margin: 0 auto 1em auto;
+  margin: 0 auto 1em;
 
   &.fullwidth {
     width: 100%;

--- a/asset/css/callout.less
+++ b/asset/css/callout.less
@@ -7,7 +7,7 @@
   width: fit-content;
   margin: 0 auto 1em;
 
-  &.fullwidth {
+  &.callout-fullwidth {
     width: 100%;
     justify-content: start;
   }
@@ -48,19 +48,19 @@
     font-size: 1.5em;
   }
 
-  &.info {
+  &.callout-type-info {
     --callout-color: @color-pending;
   }
 
-  &.success {
+  &.callout-type-success {
     --callout-color: @color-ok;
   }
 
-  &.warning {
+  &.callout-type-warning {
     --callout-color: @color-warning;
   }
 
-  &.error {
+  &.callout-type-error {
     --callout-color: @color-critical;
   }
 }

--- a/asset/css/callout.less
+++ b/asset/css/callout.less
@@ -26,6 +26,10 @@
     margin: 0;
   }
 
+  .callout-title {
+    margin-bottom: .5em;
+  }
+
   .callout-text {
     display: flex;
     flex-direction: column;

--- a/asset/css/callout.less
+++ b/asset/css/callout.less
@@ -9,6 +9,13 @@
 
   &.fullwidth {
     width: 100%;
+    justify-content: start;
+  }
+
+  &.form-callout {
+    margin-left: 14em;
+    width: auto;
+    justify-content: start;
   }
 
   i.icon::before {
@@ -22,11 +29,6 @@
   .callout-text {
     display: flex;
     flex-direction: column;
-  }
-
-  &.form-callout {
-    margin-left: 14em;
-    width: auto;
   }
 }
 

--- a/asset/css/callout.less
+++ b/asset/css/callout.less
@@ -1,0 +1,60 @@
+// Layout
+.callout {
+  display: flex;
+  justify-content: center;
+  column-gap: 1em;
+
+  width: fit-content;
+  margin: 0 auto 1em auto;
+
+  &.fullwidth {
+    width: 100%;
+  }
+
+  i.icon::before {
+    margin-right: 0;
+  }
+
+  p {
+    margin: 0;
+  }
+
+  .callout-text {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &.form-callout {
+    margin-left: 14em;
+    width: auto;
+  }
+}
+
+// Style
+.callout {
+  padding: .5em 1em;
+  border: 1px solid var(--callout-color);
+  background-color: color-mix(in srgb, var(--callout-color) 10%, transparent);
+  border-radius: .25em;
+
+  i.icon {
+    color: var(--callout-color);
+    font-size: 1.5em;
+  }
+
+  &.info {
+    --callout-color: @color-pending;
+  }
+
+  &.success {
+    --callout-color: @color-ok;
+  }
+
+  &.warning {
+    --callout-color: @color-warning;
+  }
+
+  &.error {
+    --callout-color: @color-critical;
+  }
+}

--- a/asset/css/callout.less
+++ b/asset/css/callout.less
@@ -7,12 +7,12 @@
   width: fit-content;
   margin: 0 auto 1em;
 
-  &.callout-fullwidth {
+  &.callout-full-width {
     width: 100%;
     justify-content: start;
   }
 
-  &.form-callout {
+  &.callout-form-element {
     margin-left: 14em;
     width: auto;
     justify-content: start;

--- a/asset/css/callout.less
+++ b/asset/css/callout.less
@@ -13,6 +13,11 @@
   }
 
   &.callout-form-element {
+    /*
+     * 14em is the width of the `control-label-group` element. This property value assumes that there are no
+     * special cases for which the label width differs. There is no way to get the width of the form label
+     * programmatically.
+     */
     margin-left: 14em;
     width: auto;
     justify-content: start;

--- a/asset/css/callout.less
+++ b/asset/css/callout.less
@@ -1,0 +1,60 @@
+// Layout
+.callout {
+  display: flex;
+  column-gap: 1em;
+  justify-content: start;
+
+  &.callout-fit-content {
+    width: fit-content;
+  }
+
+  i.icon::before {
+    margin-right: 0;
+  }
+
+  p {
+    margin: 0;
+  }
+
+  .callout-title {
+    margin-bottom: .5em;
+  }
+
+  .callout-text {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+// Style
+.callout {
+  padding: .5em 1em;
+  border: 1px solid var(--callout-color);
+  background-color: var(--callout-bg-color);
+  border-radius: .25em;
+
+  i.icon {
+    color: var(--callout-color);
+    font-size: 1.5em;
+  }
+
+  &.callout-type-info {
+    --callout-color: @callout-info-color;
+    --callout-bg-color: @callout-info-bg;
+  }
+
+  &.callout-type-success {
+    --callout-color: @callout-success-color;
+    --callout-bg-color: @callout-success-bg;
+  }
+
+  &.callout-type-warning {
+    --callout-color: @callout-warning-color;
+    --callout-bg-color: @callout-warning-bg;
+  }
+
+  &.callout-type-error {
+    --callout-color: @callout-error-color;
+    --callout-bg-color: @callout-error-bg;
+  }
+}

--- a/asset/css/variables.less
+++ b/asset/css/variables.less
@@ -130,6 +130,16 @@
 @schedule-element-fields-disabled-selected-bg: @base-gray-light;
 @schedule-element-keyboard-note-bg: @base-gray-light;
 
+@callout-success-color: @state-ok;
+@callout-info-color: #008fe8;
+@callout-warning-color: @state-warning;
+@callout-error-color: @state-critical;
+
+@callout-success-bg: fade(@callout-success-color, 10%);
+@callout-info-bg: fade(@callout-info-color, 10%);
+@callout-warning-bg: fade(@callout-warning-color, 10%);
+@callout-error-bg: fade(@callout-error-color, 10%);
+
 @empty-state-color: @base-gray-semilight;
 @empty-state-bar-bg: @base-gray-lighter;
 

--- a/src/Common/CalloutType.php
+++ b/src/Common/CalloutType.php
@@ -9,10 +9,10 @@ use ipl\Web\Widget\Icon;
  */
 enum CalloutType: string
 {
-    case Info = "info";
-    case Success = "success";
-    case Warning = "warning";
-    case Error = "error";
+    case Info = 'callout-type-info';
+    case Success = 'callout-type-success';
+    case Warning = 'callout-type-warning';
+    case Error = 'callout-type-error';
 
     /**
      * Get the icon element for use in the callout
@@ -21,11 +21,11 @@ enum CalloutType: string
      */
     public function getIcon(): Icon
     {
-        return match ($this) {
-            self::Info => new Icon('circle-info'),
-            self::Success => new Icon('circle-check'),
-            self::Warning => new Icon('warning'),
-            self::Error => new Icon('circle-xmark'),
-        };
+        return new Icon(match ($this) {
+            self::Info => 'circle-info',
+            self::Success => 'circle-check',
+            self::Warning => 'warning',
+            self::Error => 'circle-xmark',
+        });
     }
 }

--- a/src/Common/CalloutType.php
+++ b/src/Common/CalloutType.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ipl\Web\Common;
+
+use ipl\Web\Widget\Icon;
+
+/**
+ * An enum containing all possible callout types for the {@see Callout} widget.
+ */
+enum CalloutType: string
+{
+    case Info = "info";
+    case Success = "success";
+    case Warning = "warning";
+    case Error = "error";
+
+    /**
+     * Get the icon element for use in the callout
+     *
+     * @return Icon
+     */
+    public function getIcon(): Icon
+    {
+        return match ($this) {
+            self::Info => new Icon('circle-info'),
+            self::Success => new Icon('circle-check'),
+            self::Warning => new Icon('warning'),
+            self::Error => new Icon('circle-xmark'),
+        };
+    }
+}

--- a/src/Common/CalloutType.php
+++ b/src/Common/CalloutType.php
@@ -5,7 +5,7 @@ namespace ipl\Web\Common;
 use ipl\Web\Widget\Icon;
 
 /**
- * An enum containing all possible callout types for the {@see Callout} widget.
+ * An enum containing all possible callout types for the {@see Callout} widget
  */
 enum CalloutType: string
 {

--- a/src/Common/CalloutType.php
+++ b/src/Common/CalloutType.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ipl\Web\Common;
+
+use ipl\Web\Widget\Icon;
+
+/**
+ * An enum containing all possible callout types for the {@see \ipl\Web\Widget\Callout} widget
+ */
+enum CalloutType: string
+{
+    case Info = 'callout-type-info';
+    case Success = 'callout-type-success';
+    case Warning = 'callout-type-warning';
+    case Error = 'callout-type-error';
+
+    /**
+     * Get the icon element for use in the callout
+     *
+     * @return Icon
+     */
+    public function getIcon(): Icon
+    {
+        return new Icon(match ($this) {
+            self::Info => 'circle-info',
+            self::Success => 'circle-check',
+            self::Warning => 'warning',
+            self::Error => 'circle-xmark',
+        });
+    }
+}

--- a/src/Common/CalloutType.php
+++ b/src/Common/CalloutType.php
@@ -5,7 +5,7 @@ namespace ipl\Web\Common;
 use ipl\Web\Widget\Icon;
 
 /**
- * An enum containing all possible callout types for the {@see Callout} widget
+ * An enum containing all possible callout types for the {@see \ipl\Web\Widget\Callout} widget
  */
 enum CalloutType: string
 {

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -75,9 +75,9 @@ class Callout extends BaseHtmlElement
     public function setFullwidth(bool $fullwidth = true): static
     {
         if ($fullwidth) {
-            $this->addAttributes(Attributes::create(['class' => 'fullwidth']));
+            $this->addAttributes(Attributes::create(['class' => 'callout-fullwidth']));
         } else {
-            $this->removeAttribute('class', 'fullwidth');
+            $this->removeAttribute('class', 'callout-fullwidth');
         }
 
         return $this;

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -23,21 +23,18 @@ class Callout extends BaseHtmlElement
 
     protected $defaultAttributes = ['class' => 'callout'];
 
-    /** @var string|null An optional title */
-    protected ?string $title;
-
-    /** @var string The content to display */
-    protected string $content;
-
-    /** @var CalloutType The type of callout, determines the color and icon */
-    protected CalloutType $type;
-
-    public function __construct(CalloutType $type, string $content, ?string $title = null)
-    {
-        $this->type = $type;
-        $this->content = $content;
-        $this->title = $title;
-
+    /**
+     * Create a new callout
+     *
+     * @param CalloutType $type the type of the callout. The type determines the color and icon that is used.
+     * @param string $content the text content of the callout
+     * @param string|null $title an optional title, displayed above the content
+     */
+    public function __construct(
+        protected CalloutType $type,
+        protected string $content,
+        protected ?string $title = null
+    ) {
         $this->addAttributes(Attributes::create(['class' => $type->value]));
     }
 

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -25,11 +25,6 @@ class Callout extends BaseHtmlElement
     protected $defaultAttributes = ['class' => 'callout'];
 
     /**
-     * @var ValidHtml The content of the callout
-     */
-    protected ValidHtml $content;
-
-    /**
      * Create a new callout
      *
      * @param CalloutType $type the type of the callout. The type determines the color and icon that is used.
@@ -38,13 +33,9 @@ class Callout extends BaseHtmlElement
      */
     public function __construct(
         protected CalloutType $type,
-        ValidHtml|string $content,
+        protected ValidHtml|string $content,
         protected ?string $title = null
     ) {
-        if (is_string($content)) {
-            $content = new Text($content);
-        }
-        $this->content = $content;
         $this->addAttributes(Attributes::create(['class' => $type->value]));
     }
 
@@ -59,7 +50,7 @@ class Callout extends BaseHtmlElement
                 $this->title
                     ? HtmlElement::create('strong', ['class' => 'callout-title'], new Text($this->title))
                     : null,
-                $this->content,
+                is_string($this->content) ? new Text($this->content) : $this->content,
             ],
         ));
     }

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace ipl\Web\Widget;
+
+use ipl\Html\Attributes;
+use ipl\Html\BaseHtmlElement;
+use ipl\Html\HtmlElement;
+use ipl\Html\Text;
+use ipl\I18n\Translation;
+use ipl\Web\Common\CalloutType;
+
+/**
+ * An information box that can be used to display information to the user.
+ * It consists of a set of standardized colors and icons that can be used to visually distinguish the type of
+ * information.
+ * A content string and an optional title can be passed to the constructor.
+ */
+class Callout extends BaseHtmlElement
+{
+    use Translation;
+
+    protected $tag = 'div';
+
+    protected $defaultAttributes = ['class' => 'callout'];
+
+    /** @var string|null An optional title */
+    protected ?string $title;
+
+    /** @var string The content to display */
+    protected string $content;
+
+    /** @var CalloutType The type of callout, determines the color and icon */
+    protected CalloutType $type;
+
+    public function __construct(CalloutType $type, string $content, ?string $title = null)
+    {
+        $this->type = $type;
+        $this->content = $content;
+        $this->title = $title;
+
+        $this->addAttributes(Attributes::create(['class' => $type->value]));
+    }
+
+    public function assemble(): void
+    {
+        $this->addHtml($this->type->getIcon());
+
+        if ($this->title) {
+            $this->addHtml(HtmlElement::create(
+                'div',
+                ['class' => 'callout-text'],
+                [
+                    HtmlElement::create('strong', null, new Text($this->title)),
+                    HtmlElement::create('p', null, new Text($this->content)),
+                ],
+            ));
+        } else {
+            $this->addHtml(HtmlElement::create(
+                'div',
+                ['class' => 'callout-text'],
+                HtmlElement::create('strong', null, new Text($this->content)),
+            ));
+        }
+    }
+
+    /**
+     * Callouts are only as wide as their content.
+     * Setting it to fullwidth will force the callout to be as wide as its container.
+     *
+     * @param bool $fullwidth should the callout be fullwidth
+     *
+     * @return $this
+     */
+    public function setFullwidth(bool $fullwidth = true): static
+    {
+        if ($fullwidth) {
+            $this->addAttributes(Attributes::create(['class' => 'fullwidth']));
+        } else {
+            $this->removeAttribute('class', 'fullwidth');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Setting this to true will allow the callout to be used for a single form element.
+     * This is used to visually align the callout to the content of the form element.
+     *
+     * @param bool $isFormElement should the callout be used for a form element
+     *
+     * @return $this
+     */
+    public function setFormElement(bool $isFormElement = true): static
+    {
+        if ($isFormElement) {
+            $this->addAttributes(Attributes::create(['class' => 'form-callout']));
+        } else {
+            $this->removeAttribute('class', 'from-callout');
+        }
+
+        return $this;
+    }
+}

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -6,6 +6,7 @@ use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
+use ipl\Html\ValidHtml;
 use ipl\I18n\Translation;
 use ipl\Web\Common\CalloutType;
 
@@ -24,17 +25,26 @@ class Callout extends BaseHtmlElement
     protected $defaultAttributes = ['class' => 'callout'];
 
     /**
+     * @var ValidHtml The content of the callout
+     */
+    protected ValidHtml $content;
+
+    /**
      * Create a new callout
      *
      * @param CalloutType $type the type of the callout. The type determines the color and icon that is used.
-     * @param string $content the text content of the callout
+     * @param ValidHtml|string $content the content of the callout
      * @param string|null $title an optional title, displayed above the content
      */
     public function __construct(
         protected CalloutType $type,
-        protected string $content,
+        ValidHtml|string $content,
         protected ?string $title = null
     ) {
+        if (is_string($content)) {
+            $content = new Text($content);
+        }
+        $this->content = $content;
         $this->addAttributes(Attributes::create(['class' => $type->value]));
     }
 
@@ -42,22 +52,16 @@ class Callout extends BaseHtmlElement
     {
         $this->addHtml($this->type->getIcon());
 
-        if ($this->title) {
-            $this->addHtml(HtmlElement::create(
-                'div',
-                ['class' => 'callout-text'],
-                [
-                    HtmlElement::create('strong', null, new Text($this->title)),
-                    HtmlElement::create('p', null, new Text($this->content)),
-                ],
-            ));
-        } else {
-            $this->addHtml(HtmlElement::create(
-                'div',
-                ['class' => 'callout-text'],
-                HtmlElement::create('strong', null, new Text($this->content)),
-            ));
-        }
+        $this->addHtml(HtmlElement::create(
+            'div',
+            ['class' => 'callout-text'],
+            [
+                $this->title
+                    ? HtmlElement::create('strong', ['class' => 'callout-title'], new Text($this->title))
+                    : null,
+                $this->content,
+            ],
+        ));
     }
 
     /**

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -12,13 +12,19 @@ use ipl\Web\Common\CalloutType;
 
 /**
  * An information box that can be used to display information to the user.
- * It consists of a set of standardized colors and icons that can be used to visually distinguish the type of
- * information.
- * A content string and an optional title can be passed to the constructor.
+ * It consists of a set of standardized colors and icons that can be used to
+ * visually distinguish the type of information. A content string and an
+ * optional title can be passed to the constructor.
  */
 class Callout extends BaseHtmlElement
 {
     use Translation;
+
+    /** @var string Classname for form-element callouts */
+    protected const CLASS_FORM_ELEMENT = 'callout-form-element';
+
+    /** @var string Classname for full-width callouts */
+    protected const CLASS_FULL_WIDTH = 'callout-full-width';
 
     protected $tag = 'div';
 
@@ -27,9 +33,11 @@ class Callout extends BaseHtmlElement
     /**
      * Create a new callout
      *
-     * @param CalloutType $type the type of the callout. The type determines the color and icon that is used.
-     * @param ValidHtml|string $content the content of the callout
-     * @param string|null $title an optional title, displayed above the content
+     * The $type parameter determines the color and icon of the callout.
+     *
+     * @param CalloutType $type The type of the callout.
+     * @param ValidHtml|string $content The content of the callout
+     * @param string|null $title An optional title, displayed above the content
      */
     public function __construct(
         protected CalloutType $type,
@@ -56,25 +64,29 @@ class Callout extends BaseHtmlElement
     }
 
     /**
-     * Callouts are only as wide as their content.
+     * Set the callout width to be 100% of its parent container
+     *
+     * Callouts are normally only as wide as their content.
      * Setting it to fullwidth will force the callout to be as wide as its container.
      *
-     * @param bool $fullwidth Whether the callout should be full width
+     * @param bool $isFullWidth Whether the callout should be full width
      *
      * @return $this
      */
-    public function setFullwidth(bool $fullwidth = true): static
+    public function setFullwidth(bool $isFullWidth = true): static
     {
-        if ($fullwidth) {
-            $this->addAttributes(Attributes::create(['class' => 'callout-fullwidth']));
+        if ($isFullWidth) {
+            $this->addAttributes(Attributes::create(['class' => static::CLASS_FULL_WIDTH]));
         } else {
-            $this->removeAttribute('class', 'callout-fullwidth');
+            $this->removeAttribute('class', static::CLASS_FULL_WIDTH);
         }
 
         return $this;
     }
 
     /**
+     * Set up the callout to be used inside a form
+     *
      * Setting this to true will allow the callout to be used for a single form element.
      * This is used to visually align the callout to the content of the form element.
      *
@@ -85,9 +97,9 @@ class Callout extends BaseHtmlElement
     public function setFormElement(bool $isFormElement = true): static
     {
         if ($isFormElement) {
-            $this->addAttributes(Attributes::create(['class' => 'form-callout']));
+            $this->addAttributes(Attributes::create(['class' => static::CLASS_FORM_ELEMENT]));
         } else {
-            $this->removeAttribute('class', 'form-callout');
+            $this->removeAttribute('class', static::CLASS_FORM_ELEMENT);
         }
 
         return $this;

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -2,7 +2,6 @@
 
 namespace ipl\Web\Widget;
 
-use InvalidArgumentException;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlElement;

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -7,7 +7,6 @@ use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
 use ipl\Html\ValidHtml;
-use ipl\I18n\Translation;
 use ipl\Web\Common\CalloutType;
 
 /**
@@ -18,8 +17,6 @@ use ipl\Web\Common\CalloutType;
  */
 class Callout extends BaseHtmlElement
 {
-    use Translation;
-
     /** @var string Class name for form element callouts */
     protected const CLASS_FORM_ELEMENT = 'callout-form-element';
 

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -11,10 +11,10 @@ use ipl\I18n\Translation;
 use ipl\Web\Common\CalloutType;
 
 /**
- * An information box that can be used to display information to the user.
- * It consists of a set of standardized colors and icons that can be used to
- * visually distinguish the type of information. A content string and an
- * optional title can be passed to the constructor.
+ * Information box with a type specific color and icon
+ *
+ * The type controls both the color scheme and the icon. An optional title
+ * is displayed above the content.
  */
 class Callout extends BaseHtmlElement
 {
@@ -64,10 +64,10 @@ class Callout extends BaseHtmlElement
     }
 
     /**
-     * Set the callout width to be 100% of its parent container
+     * Set the callout width to 100% of its parent container
      *
      * Callouts are normally only as wide as their content.
-     * Setting it to fullwidth will force the callout to be as wide as its container.
+     * Setting it to full width will force the callout to be as wide as its container.
      *
      * @param bool $isFullWidth Whether the callout should be full width
      *

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -73,7 +73,7 @@ class Callout extends BaseHtmlElement
      *
      * @return $this
      */
-    public function setFullwidth(bool $isFullWidth = true): static
+    public function setFullWidth(bool $isFullWidth = true): static
     {
         if ($isFullWidth) {
             $this->addAttributes(Attributes::create(['class' => static::CLASS_FULL_WIDTH]));

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Web\Widget;
 
+use InvalidArgumentException;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlElement;
@@ -52,7 +53,7 @@ class Callout extends BaseHtmlElement
             'div',
             ['class' => 'callout-text'],
             [
-                $this->title
+                $this->title !== null
                     ? HtmlElement::create('strong', ['class' => 'callout-title'], Text::create($this->title))
                     : null,
                 is_string($this->content) ? Text::create($this->content) : $this->content,

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -39,7 +39,7 @@ class Callout extends BaseHtmlElement
         $this->addAttributes(Attributes::create(['class' => $type->value]));
     }
 
-    public function assemble(): void
+    protected function assemble(): void
     {
         $this->addHtml($this->type->getIcon());
 
@@ -59,7 +59,7 @@ class Callout extends BaseHtmlElement
      * Callouts are only as wide as their content.
      * Setting it to fullwidth will force the callout to be as wide as its container.
      *
-     * @param bool $fullwidth should the callout be fullwidth
+     * @param bool $fullwidth Whether the callout should be full width
      *
      * @return $this
      */
@@ -78,7 +78,7 @@ class Callout extends BaseHtmlElement
      * Setting this to true will allow the callout to be used for a single form element.
      * This is used to visually align the callout to the content of the form element.
      *
-     * @param bool $isFormElement should the callout be used for a form element
+     * @param bool $isFormElement Whether the callout should be used for a form element
      *
      * @return $this
      */
@@ -87,7 +87,7 @@ class Callout extends BaseHtmlElement
         if ($isFormElement) {
             $this->addAttributes(Attributes::create(['class' => 'form-callout']));
         } else {
-            $this->removeAttribute('class', 'from-callout');
+            $this->removeAttribute('class', 'form-callout');
         }
 
         return $this;

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace ipl\Web\Widget;
+
+use ipl\Html\Attributes;
+use ipl\Html\BaseHtmlElement;
+use ipl\Html\HtmlElement;
+use ipl\Html\Text;
+use ipl\Html\ValidHtml;
+use ipl\Web\Common\CalloutType;
+
+/**
+ * Information box with a type specific color and icon
+ *
+ * The type controls both the color scheme and the icon. An optional title
+ * is displayed above the content.
+ */
+class Callout extends BaseHtmlElement
+{
+    /** @var string Class name for fit content callouts */
+    protected const CLASS_FIT_CONTENT = 'callout-fit-content';
+
+    protected $tag = 'div';
+
+    protected $defaultAttributes = ['class' => 'callout'];
+
+    /**
+     * Create a new callout
+     *
+     * The $type parameter determines the color and icon of the callout.
+     *
+     * @param CalloutType $type The type of the callout
+     * @param ValidHtml|string $content The content of the callout
+     * @param ?string $title An optional title, displayed above the content
+     */
+    public function __construct(
+        protected CalloutType $type,
+        protected ValidHtml|string $content,
+        protected ?string $title = null
+    ) {
+        $this->addAttributes(Attributes::create(['class' => $type->value]));
+    }
+
+    protected function assemble(): void
+    {
+        $this->addHtml($this->type->getIcon());
+
+        $this->addHtml(HtmlElement::create(
+            'div',
+            ['class' => 'callout-text'],
+            [
+                $this->title === null || trim($this->title) === ''
+                    ? null
+                    : HtmlElement::create('strong', ['class' => 'callout-title'], Text::create($this->title)),
+                is_string($this->content) ? Text::create($this->content) : $this->content,
+            ],
+        ));
+    }
+
+    /**
+     * Set the callout width to 100% of its parent container
+     *
+     * Callouts are by default sized to fill their parent container.
+     *
+     * @param bool $isFitContent Whether the callout size should be dependent on its content
+     *
+     * @return $this
+     */
+    public function setFitContent(bool $isFitContent = true): static
+    {
+        if ($isFitContent) {
+            $this->addAttributes(Attributes::create(['class' => static::CLASS_FIT_CONTENT]));
+        } else {
+            $this->removeAttribute('class', static::CLASS_FIT_CONTENT);
+        }
+
+        return $this;
+    }
+}

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -20,10 +20,10 @@ class Callout extends BaseHtmlElement
 {
     use Translation;
 
-    /** @var string Classname for form-element callouts */
+    /** @var string Class name for form element callouts */
     protected const CLASS_FORM_ELEMENT = 'callout-form-element';
 
-    /** @var string Classname for full-width callouts */
+    /** @var string Class name for full width callouts */
     protected const CLASS_FULL_WIDTH = 'callout-full-width';
 
     protected $tag = 'div';
@@ -35,9 +35,9 @@ class Callout extends BaseHtmlElement
      *
      * The $type parameter determines the color and icon of the callout.
      *
-     * @param CalloutType $type The type of the callout.
+     * @param CalloutType $type The type of the callout
      * @param ValidHtml|string $content The content of the callout
-     * @param string|null $title An optional title, displayed above the content
+     * @param ?string $title An optional title, displayed above the content
      */
     public function __construct(
         protected CalloutType $type,
@@ -56,9 +56,9 @@ class Callout extends BaseHtmlElement
             ['class' => 'callout-text'],
             [
                 $this->title
-                    ? HtmlElement::create('strong', ['class' => 'callout-title'], new Text($this->title))
+                    ? HtmlElement::create('strong', ['class' => 'callout-title'], Text::create($this->title))
                     : null,
-                is_string($this->content) ? new Text($this->content) : $this->content,
+                is_string($this->content) ? Text::create($this->content) : $this->content,
             ],
         ));
     }

--- a/tests/Widget/CalloutTest.php
+++ b/tests/Widget/CalloutTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace ipl\Tests\Web\Widget;
+
+use ipl\Html\Html;
+use ipl\Html\Test\TestCase;
+use ipl\Web\Common\CalloutType;
+use ipl\Web\Widget\Callout;
+
+class CalloutTest extends TestCase
+{
+    public function testCalloutWithoutTitle(): void
+    {
+        $callout = new Callout(CalloutType::Info, 'Content');
+
+        $html = <<<'HTML'
+<div class="callout callout-type-info">
+    <i class="icon fa-circle-info fa"></i>
+    <div class="callout-text">
+        Content
+    </div>
+</div>
+HTML;
+
+        $this->assertHtml($html, $callout);
+    }
+
+    public function testCalloutWithTitle(): void
+    {
+        $callout = new Callout(CalloutType::Info, 'Content', 'Title');
+
+        $html = <<<'HTML'
+<div class="callout callout-type-info">
+    <i class="icon fa-circle-info fa"></i>
+    <div class="callout-text">
+        <strong class="callout-title">Title</strong>
+        Content
+    </div>
+</div>
+HTML;
+
+        $this->assertHtml($html, $callout);
+    }
+
+    public function testCalloutFalsyTitle(): void
+    {
+        $callout = new Callout(CalloutType::Warning, 'Content', '0');
+
+        $html = <<<'HTML'
+<div class="callout callout-type-warning">
+    <i class="icon fa-warning fa"></i>
+    <div class="callout-text">
+        <strong class="callout-title">0</strong>
+        Content
+    </div>
+</div>
+HTML;
+        $this->assertHtml($html, $callout);
+    }
+
+    public function testCalloutEmptyTitle(): void
+    {
+        $callout = new Callout(CalloutType::Error, 'Content', '');
+
+        $html = <<<'HTML'
+<div class="callout callout-type-error">
+    <i class="icon fa-circle-xmark fa"></i>
+    <div class="callout-text">
+        Content
+    </div>
+</div>
+HTML;
+        $this->assertHtml($html, $callout);
+    }
+
+    public function testCalloutValidHtmlContent(): void
+    {
+        $callout = new Callout(
+            CalloutType::Success,
+            Html::tag('p', ['class' => 'test-class'], 'This is a Test'),
+            'Test Title',
+        );
+
+        $html = <<<'HTML'
+<div class="callout callout-type-success">
+    <i class="icon fa-circle-check fa"></i>
+    <div class="callout-text">
+        <strong class="callout-title">Test Title</strong>
+        <p class="test-class">This is a Test</p>
+    </div>
+</div>
+HTML;
+
+        $this->assertHtml($html, $callout);
+    }
+
+    public function testCalloutFitContent(): void
+    {
+        $callout = (new Callout(CalloutType::Error, 'Content'))
+            ->setFitContent(true);
+
+        $html = <<<'HTML'
+<div class="callout callout-type-error callout-fit-content">
+    <i class="icon fa-circle-xmark fa"></i>
+    <div class="callout-text">
+        Content
+    </div>
+</div>
+HTML;
+        $this->assertHtml($html, $callout);
+
+        $callout->setFitContent(false);
+
+        $html2 = <<<'HTML'
+<div class="callout callout-type-error">
+    <i class="icon fa-circle-xmark fa"></i>
+    <div class="callout-text">
+        Content
+    </div>
+</div>
+HTML;
+        $this->assertHtml($html2, $callout);
+    }
+}

--- a/tests/Widget/CalloutTest.php
+++ b/tests/Widget/CalloutTest.php
@@ -9,6 +9,22 @@ use ipl\Web\Widget\Callout;
 
 class CalloutTest extends TestCase
 {
+    public function testCalloutWithoutTitle(): void
+    {
+        $callout = new Callout(CalloutType::Info, 'Content');
+
+        $html = <<<'HTML'
+<div class="callout callout-type-info">
+    <i class="icon fa-circle-info fa"></i>
+    <div class="callout-text">
+        Content
+    </div>
+</div>
+HTML;
+
+        $this->assertHtml($html, $callout);
+    }
+
     public function testCalloutWithTitle(): void
     {
         $callout = new Callout(CalloutType::Info, 'Content', 'Title');

--- a/tests/Widget/CalloutTest.php
+++ b/tests/Widget/CalloutTest.php
@@ -94,4 +94,60 @@ HTML;
 
         $this->assertHtml($html, $callout);
     }
+
+    public function testCalloutFullWidth(): void
+    {
+        $callout = (new Callout(CalloutType::Error, 'Content'))
+            ->setFullWidth(true);
+
+        $html = <<<'HTML'
+<div class="callout callout-type-error callout-full-width">
+    <i class="icon fa-circle-xmark fa"></i>
+    <div class="callout-text">
+        Content
+    </div>
+</div>
+HTML;
+        $this->assertHtml($html, $callout);
+
+        $callout->setFullWidth(false);
+
+        $html2 = <<<'HTML'
+<div class="callout callout-type-error">
+    <i class="icon fa-circle-xmark fa"></i>
+    <div class="callout-text">
+        Content
+    </div>
+</div>
+HTML;
+        $this->assertHtml($html2, $callout);
+    }
+
+    public function testCalloutFormElement(): void
+    {
+        $callout = (new Callout(CalloutType::Error, 'Content'))
+            ->setFormElement(true);
+
+        $html = <<<'HTML'
+<div class="callout callout-type-error callout-form-element">
+    <i class="icon fa-circle-xmark fa"></i>
+    <div class="callout-text">
+        Content
+    </div>
+</div>
+HTML;
+        $this->assertHtml($html, $callout);
+
+        $callout->setFormElement(false);
+
+        $html2 = <<<'HTML'
+<div class="callout callout-type-error">
+    <i class="icon fa-circle-xmark fa"></i>
+    <div class="callout-text">
+        Content
+    </div>
+</div>
+HTML;
+        $this->assertHtml($html2, $callout);
+    }
 }

--- a/tests/Widget/CalloutTest.php
+++ b/tests/Widget/CalloutTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace ipl\Tests\Web\Widget;
+
+use ipl\Html\Html;
+use ipl\Html\Test\TestCase;
+use ipl\Web\Common\CalloutType;
+use ipl\Web\Widget\Callout;
+
+class CalloutTest extends TestCase
+{
+    public function testCalloutWithTitle(): void
+    {
+        $callout = new Callout(CalloutType::Info, 'Content', 'Title');
+
+        $html = <<<'HTML'
+<div class="callout callout-type-info">
+    <i class="icon fa-circle-info fa"></i>
+    <div class="callout-text">
+        <strong class="callout-title">Title</strong>
+        Content
+    </div>
+</div>
+HTML;
+
+        $this->assertHtml($html, $callout);
+    }
+
+    public function testCalloutFalsyTitle(): void
+    {
+        $callout = new Callout(CalloutType::Warning, 'Content', '0');
+
+        $html = <<<'HTML'
+<div class="callout callout-type-warning">
+    <i class="icon fa-warning fa"></i>
+    <div class="callout-text">
+        <strong class="callout-title">0</strong>
+        Content
+    </div>
+</div>
+HTML;
+        $this->assertHtml($html, $callout);
+    }
+
+    public function testCalloutEmptyTitle(): void
+    {
+        $callout = new Callout(CalloutType::Error, 'Content', '');
+
+        $html = <<<'HTML'
+<div class="callout callout-type-error">
+    <i class="icon fa-circle-xmark fa"></i>
+    <div class="callout-text">
+        <strong class="callout-title"></strong>
+        Content
+    </div>
+</div>
+HTML;
+        $this->assertHtml($html, $callout);
+    }
+
+    public function testCalloutValidHtmlContent(): void
+    {
+        $callout = new Callout(
+            CalloutType::Success,
+            Html::tag('p', ['class' => 'test-class'], 'This is a Test'),
+            'Test Title',
+        );
+
+        $html = <<<'HTML'
+<div class="callout callout-type-success">
+    <i class="icon fa-circle-check fa"></i>
+    <div class="callout-text">
+        <strong class="callout-title">Test Title</strong>
+        <p class="test-class">This is a Test</p>
+    </div>
+</div>
+HTML;
+
+        $this->assertHtml($html, $callout);
+    }
+}


### PR DESCRIPTION
Implement a callout box element that can be used to convey important information to the user.
This element is designed to be used above certain form elements, over the whole form or page.

It seems like the use of callout could conflict with the existing `FormDescription` and `FormNotification` decorators, at least within IW2 forms.
Callouts are not meant as a direct replacement for these decorators but as a more universal ipl widget that can be used even outside of forms to convey essential information to the user.

Merging these two concepts by extending the form-notification would be a viable alternative to this PR.

Callout types:
<img width="397" height="265" alt="image" src="https://github.com/user-attachments/assets/fd590741-abc3-4051-9e34-324a3115b79f" />

Callout full width:
<img width="703" height="115" alt="image" src="https://github.com/user-attachments/assets/3d658c37-d2e9-4e48-97c7-84dd889f1145" />

Callout with optional title:
<img width="1018" height="144" alt="image" src="https://github.com/user-attachments/assets/5d065bdd-be40-4446-8e00-a5046d464cee" />

Callout above a form element:
<img width="1161" height="300" alt="image" src="https://github.com/user-attachments/assets/7a03b7fb-dd24-457f-9d2a-5b94194aee5c" />

closes #349

~requires Icinga/ipl-stdlib#77~