### PR TITLE
Repository housekeeping

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Exclude Git and CI configuration files from archives.
+.git* export-ignore
+
+# Exclude test-related files from archives.
+tests/ export-ignore
+phpstan* export-ignore

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
+      - support/*
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   php:

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
-# Exclude all hidden files
-.*
-
-# Except those related to Git (and GitHub)
-!.git*
-
-# Exclude files from composer install
+# Ignore Composer installation artifacts; composer.lock is intentionally
+# excluded as this is a library - applications depending on this package
+# manage their own lock file.
 /vendor/
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,33 @@
 {
   "name": "ipl/web",
-  "type": "library",
   "description": "Icinga PHP Library - Web Components",
-  "keywords": ["html"],
-  "homepage": "https://github.com/Icinga/ipl-web",
   "license": "MIT",
+  "type": "library",
+  "keywords": [
+    "html"
+  ],
+  "homepage": "https://github.com/Icinga/ipl-web",
+  "require": {
+    "php": ">=8.2",
+    "ext-json": "*",
+    "fortawesome/font-awesome": "^6",
+    "icinga/zf1": ">=2.0.0",
+    "ipl/html": ">=0.10.0",
+    "ipl/i18n": ">=1.0.0",
+    "ipl/orm": ">=0.8.0",
+    "ipl/scheduler": ">=0.3.0",
+    "ipl/stdlib": ">=0.15.0",
+    "psr/http-message": "^1.1",
+    "wikimedia/less.php": "^3.2.1"
+  },
+  "require-dev": {
+    "icinga/zf1": "dev-main",
+    "ipl/html": "dev-main",
+    "ipl/i18n": "dev-main",
+    "ipl/orm": "dev-main",
+    "ipl/scheduler": "dev-main",
+    "ipl/stdlib": "dev-main"
+  },
   "repositories": [
     {
       "type": "vcs",
@@ -21,25 +44,7 @@
       "ipl\\Tests\\Web\\": "tests"
     }
   },
-  "require": {
-    "php": ">=8.2",
-    "ext-json": "*",
-    "psr/http-message": "^1.1",
-    "icinga/zf1": ">=2.0.0",
-    "ipl/html": ">=0.10.0",
-    "ipl/i18n": ">=1.0.0",
-    "ipl/orm": ">=0.8.0",
-    "ipl/scheduler": ">=0.3.0",
-    "ipl/stdlib": ">=0.15.0",
-    "fortawesome/font-awesome": "^6",
-    "wikimedia/less.php": "^3.2.1"
-  },
-  "require-dev": {
-    "icinga/zf1": "dev-main",
-    "ipl/html": "dev-main",
-    "ipl/i18n": "dev-main",
-    "ipl/orm": "dev-main",
-    "ipl/scheduler": "dev-main",
-    "ipl/stdlib": "dev-main"
+  "config": {
+    "sort-packages": true
   }
 }


### PR DESCRIPTION
Apply a set of maintenance changes to normalize repository configuration:

- Extend CI to build on `support/*` branches, run for all PRs
  regardless of target, and allow manual dispatch
- Normalize `composer.json`
- Add `.gitattributes` to exclude CI and test files from `git archive`
- Tighten `.gitignore` to cover only Composer artifacts