### PR TITLE
Add a hasLinks method to Dropdown

### DIFF
--- a/src/Widget/Dropdown.php
+++ b/src/Widget/Dropdown.php
@@ -60,4 +60,14 @@ class Dropdown extends BaseHtmlElement
     {
         $this->add(Html::tag('div', ['class' => 'dropdown-menu'], $this->links));
     }
+
+    /**
+     * Check if the dropdown element contains any links
+     *
+     * @return bool
+     */
+    public function hasLinks(): bool
+    {
+        return ! empty($this->links);
+    }
 }


### PR DESCRIPTION
Provides a new method `hasLinks` to check if the Dropdown element has at least one link.

`isEmpty` does have another meaning, namely that the element doesn't have any content at all, which is always false for this element, so I didn't want to use that method.

This can be useful to decide if one should include the dropdown at all, since a dropdown without any links doesn't serve a purpose in most situations.