### PR TITLE
Fix handling of empty suggestion values

### DIFF
--- a/src/Control/SearchBar/Suggestions.php
+++ b/src/Control/SearchBar/Suggestions.php
@@ -247,6 +247,10 @@ abstract class Suggestions extends BaseHtmlElement
                 $term = $meta;
             }
 
+            if ($term === '') {
+                continue;
+            }
+
             if ($this->searchTerm) {
                 // Only the first exact match will set this to true, any other to false
                 $noDefault = $noDefault === null && $term === $this->searchTerm;


### PR DESCRIPTION
fixes #295 
Empty values are no longer suggested, since selecting them caused an error.