### PR TITLE
Move `data-ago-label` to `TimeUntil`

### DIFF
--- a/src/Widget/Time.php
+++ b/src/Widget/Time.php
@@ -138,17 +138,6 @@ class Time extends BaseHtmlElement
      */
     protected function assemble(): void
     {
-        $this->addAttributes(
-            Attributes::create(
-                [
-                    'data-ago-label' => sprintf(
-                        $this->translate('%s ago', 'An event that happened the given time interval ago'),
-                        '0m 0s'
-                    )
-                ]
-            )
-        );
-
         $this->addAttributes(Attributes::create(['datetime' => $this->timeString]));
         $this->addHtml(Text::create($this->format()));
     }

--- a/src/Widget/TimeUntil.php
+++ b/src/Widget/TimeUntil.php
@@ -32,6 +32,19 @@ class TimeUntil extends Time
     {
         [$time, $type, $interval] = $this->diff($this->compareTime);
 
+        if ($interval->days === 0 && $interval->h === 0) {
+            $this->addAttributes(
+                Attributes::create(
+                    [
+                        'data-ago-label' => sprintf(
+                            $this->translate('%s ago', 'An event that happened the given time interval ago'),
+                            '0m 0s'
+                        )
+                    ]
+                )
+            );
+        }
+
         if (
             $interval->invert !== 1 && $type === static::RELATIVE
             && ($interval->days !== 0 || $interval->h !== 0 || $interval->i !== 0 || $interval->s !== 0)

--- a/tests/Widget/TimeAgoTest.php
+++ b/tests/Widget/TimeAgoTest.php
@@ -20,8 +20,7 @@ class TimeAgoTest extends TestCase
     {
         $nowDateTime = new DateTime();
         $html = sprintf(
-            '<time class="time-ago" data-relative-time="ago" title="%1$s" datetime="%1$s"'
-            . ' data-ago-label="0m 0s ago">0m 0s ago</time>',
+            '<time class="time-ago" data-relative-time="ago" title="%1$s" datetime="%1$s">0m 0s ago</time>',
             $nowDateTime->format('Y-m-d H:i:s'),
         );
 
@@ -33,8 +32,7 @@ class TimeAgoTest extends TestCase
     {
         $html = <<<'HTML'
 <time class="time-ago" data-relative-time="ago"
-      title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07"
-      data-ago-label="0m 0s ago">30m 0s ago</time>
+      title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">30m 0s ago</time>
 HTML;
 
         $timestampEvent = mktime(14, 17, 7, 3, 17, 2026);
@@ -48,8 +46,7 @@ HTML;
     {
         $html = <<<'HTML'
 <time class="time-ago" data-relative-time="ago"
-      title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07"
-      data-ago-label="0m 0s ago">30m 0s ago</time>
+      title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">30m 0s ago</time>
 HTML;
 
         $this->assertHtml(
@@ -61,7 +58,7 @@ HTML;
     public function testFormatWithHoursAgoSameDay(): void
     {
         $html = <<<'HTML'
-<time class="time-ago" data-ago-label="0m 0s ago" data-relative-time="ago"
+<time class="time-ago" data-relative-time="ago"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">at 14:17</time>
 HTML;
 
@@ -74,7 +71,7 @@ HTML;
     public function testFormatWithDaysAgo(): void
     {
         $html = <<<'HTML'
-<time class="time-ago" data-ago-label="0m 0s ago" data-relative-time="ago"
+<time class="time-ago" data-relative-time="ago"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">on Mar 17</time>
 HTML;
 
@@ -87,7 +84,7 @@ HTML;
     public function testFormatWithDaysAndHoursAgo(): void
     {
         $html = <<<'HTML'
-<time class="time-ago" data-ago-label="0m 0s ago" data-relative-time="ago"
+<time class="time-ago" data-relative-time="ago"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">1d 12h ago</time>
 HTML;
 
@@ -100,7 +97,7 @@ HTML;
     public function testFormatCrossMidnightLessThanDayAgo(): void
     {
         $html = <<<'HTML'
-<time class="time-ago" data-ago-label="0m 0s ago" data-relative-time="ago"
+<time class="time-ago" data-relative-time="ago"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">on Mar 17 14:17</time>
 HTML;
 
@@ -115,25 +112,25 @@ HTML;
         $eventTime = new DateTime('2026-12-31 23:47:07');
 
         $this->assertHtml(
-            '<time class="time-ago" data-ago-label="0m 0s ago" data-relative-time="ago"'
+            '<time class="time-ago" data-relative-time="ago"'
             . ' title="2026-12-31 23:47:07" datetime="2026-12-31 23:47:07">on 2026-12</time>',
             new TimeAgo($eventTime, new DateTime('2027-03-17 14:17:07'))
         );
 
         $this->assertHtml(
-            '<time class="time-ago" data-ago-label="0m 0s ago" data-relative-time="ago"'
+            '<time class="time-ago" data-relative-time="ago"'
             . ' title="2026-12-31 23:47:07" datetime="2026-12-31 23:47:07">1d 10h ago</time>',
             new TimeAgo($eventTime, new DateTime('2027-01-02 09:47:07'))
         );
 
         $this->assertHtml(
-            '<time class="time-ago" data-ago-label="0m 0s ago" data-relative-time="ago"'
+            '<time class="time-ago" data-relative-time="ago"'
             . ' title="2026-12-31 23:47:07" datetime="2026-12-31 23:47:07">on Dec 31 23:47</time>',
             new TimeAgo($eventTime, new DateTime('2027-01-01 09:47:07'))
         );
 
         $this->assertHtml(
-            '<time class="time-ago" data-ago-label="0m 0s ago" data-relative-time="ago"'
+            '<time class="time-ago" data-relative-time="ago"'
             . ' title="2026-12-31 23:47:07" datetime="2026-12-31 23:47:07">30m 0s ago</time>',
             new TimeAgo($eventTime, new DateTime('2027-01-01 00:17:07'))
         );
@@ -143,8 +140,7 @@ HTML;
     {
         $html = <<<'HTML'
 <time class="time-ago" data-relative-time="ago"
-      title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07"
-      data-ago-label="0m 0s ago">30m 0s ago</time>
+      title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">30m 0s ago</time>
 HTML;
 
         $this->assertHtml(
@@ -156,7 +152,7 @@ HTML;
     public function testRenderIgnoresFormatter(): void
     {
         $html = <<<'HTML'
-<time class="time-ago" data-ago-label="0m 0s ago" data-relative-time="ago"
+<time class="time-ago" data-relative-time="ago"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">at 14:17</time>
 HTML;
 

--- a/tests/Widget/TimeSinceTest.php
+++ b/tests/Widget/TimeSinceTest.php
@@ -20,7 +20,7 @@ class TimeSinceTest extends TestCase
     {
         $nowDateTime = new DateTime();
         $html = sprintf(
-            '<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"'
+            '<time class="time-since" data-relative-time="since"'
             . ' title="%1$s" datetime="%1$s">for 0m 0s</time>',
             $nowDateTime->format('Y-m-d H:i:s'),
         );
@@ -32,7 +32,7 @@ class TimeSinceTest extends TestCase
     public function testConstructorAcceptsTimestamp(): void
     {
         $html = <<<'HTML'
-<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"
+<time class="time-since" data-relative-time="since"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">for 30m 0s</time>
 HTML;
 
@@ -46,7 +46,7 @@ HTML;
     public function testFormatWithSubHourTime(): void
     {
         $html = <<<'HTML'
-<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"
+<time class="time-since" data-relative-time="since"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">for 30m 0s</time>
 HTML;
 
@@ -59,7 +59,7 @@ HTML;
     public function testFormatWithHoursAgoSameDay(): void
     {
         $html = <<<'HTML'
-<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"
+<time class="time-since" data-relative-time="since"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">since 14:17</time>
 HTML;
 
@@ -72,7 +72,7 @@ HTML;
     public function testFormatWithDaysAgo(): void
     {
         $html = <<<'HTML'
-<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"
+<time class="time-since" data-relative-time="since"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">since Mar 17</time>
 HTML;
 
@@ -85,7 +85,7 @@ HTML;
     public function testFormatWithDaysAndHoursAgo(): void
     {
         $html = <<<'HTML'
-<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"
+<time class="time-since" data-relative-time="since"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">for 1d 12h</time>
 HTML;
 
@@ -98,7 +98,7 @@ HTML;
     public function testFormatCrossMidnightLessThanDayAgo(): void
     {
         $html = <<<'HTML'
-<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"
+<time class="time-since" data-relative-time="since"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">since Mar 17 14:17</time>
 HTML;
 
@@ -113,25 +113,25 @@ HTML;
         $eventTime = new DateTime('2026-12-31 23:47:07');
 
         $this->assertHtml(
-            '<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"'
+            '<time class="time-since" data-relative-time="since"'
             . ' title="2026-12-31 23:47:07" datetime="2026-12-31 23:47:07">since 2026-12</time>',
             new TimeSince($eventTime, new DateTime('2027-03-17 14:17:07'))
         );
 
         $this->assertHtml(
-            '<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"'
+            '<time class="time-since" data-relative-time="since"'
             . ' title="2026-12-31 23:47:07" datetime="2026-12-31 23:47:07">for 1d 10h</time>',
             new TimeSince($eventTime, new DateTime('2027-01-02 09:47:07'))
         );
 
         $this->assertHtml(
-            '<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"'
+            '<time class="time-since" data-relative-time="since"'
             . ' title="2026-12-31 23:47:07" datetime="2026-12-31 23:47:07">since Dec 31 23:47</time>',
             new TimeSince($eventTime, new DateTime('2027-01-01 09:47:07'))
         );
 
         $this->assertHtml(
-            '<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"'
+            '<time class="time-since" data-relative-time="since"'
             . ' title="2026-12-31 23:47:07" datetime="2026-12-31 23:47:07">for 30m 0s</time>',
             new TimeSince($eventTime, new DateTime('2027-01-01 00:17:07'))
         );
@@ -140,7 +140,7 @@ HTML;
     public function testFormatWithFutureSubHourShowsAgoSuffix(): void
     {
         $html = <<<'HTML'
-<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"
+<time class="time-since" data-relative-time="since"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">for 30m 0s</time>
 HTML;
 
@@ -153,7 +153,7 @@ HTML;
     public function testRenderIgnoresFormatter(): void
     {
         $html = <<<'HTML'
-<time class="time-since" data-ago-label="0m 0s ago" data-relative-time="since"
+<time class="time-since" data-relative-time="since"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">since 14:17</time>
 HTML;
 

--- a/tests/Widget/TimeTest.php
+++ b/tests/Widget/TimeTest.php
@@ -33,7 +33,7 @@ class TimeTest extends TestCase
     public function testConstructorAcceptsNullForCurrentTime(): void
     {
         $now = '2026-03-17 14:17:07';
-        $html = sprintf('<time title="%1$s" data-ago-label="0m 0s ago"  datetime="%1$s">%1$s</time>', $now);
+        $html = sprintf('<time title="%1$s" datetime="%1$s">%1$s</time>', $now);
 
         $this->assertHtml($html, new Time(new DateTime($now)));
     }
@@ -41,7 +41,7 @@ class TimeTest extends TestCase
     public function testRenderUsesFormatter(): void
     {
         $html = <<<'HTML'
-<time title="2026-03-17 14:17:07" data-ago-label="0m 0s ago"  datetime="2026-03-17 14:17:07">2026_3_17 14:17</time>
+<time title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">2026_3_17 14:17</time>
 HTML;
 
         $widget = new Time(new DateTime('2026-03-17 14:17:07'));

--- a/tests/Widget/TimeUntilTest.php
+++ b/tests/Widget/TimeUntilTest.php
@@ -61,7 +61,7 @@ HTML;
     public function testFormatWithHoursAgoSameDay(): void
     {
         $html = <<<'HTML'
-<time class="time-until" data-ago-label="0m 0s ago" data-relative-time="until"
+<time class="time-until" data-relative-time="until"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">at 14:17</time>
 HTML;
 
@@ -74,7 +74,7 @@ HTML;
     public function testFormatWithDaysAgo(): void
     {
         $html = <<<'HTML'
-<time class="time-until" data-ago-label="0m 0s ago" data-relative-time="until"
+<time class="time-until" data-relative-time="until"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">on Mar 17</time>
 HTML;
 
@@ -87,7 +87,7 @@ HTML;
     public function testFormatWithDaysAndHoursAgo(): void
     {
         $html = <<<'HTML'
-<time class="time-until" data-ago-label="0m 0s ago" data-relative-time="until"
+<time class="time-until" data-relative-time="until"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">in 1d 12h</time>
 HTML;
 
@@ -100,7 +100,7 @@ HTML;
     public function testFormatCrossMidnightLessThanDayAgo(): void
     {
         $html = <<<'HTML'
-<time class="time-until" data-ago-label="0m 0s ago" data-relative-time="until"
+<time class="time-until" data-relative-time="until"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">on Mar 17 14:17</time>
 HTML;
 
@@ -115,19 +115,19 @@ HTML;
         $eventTime = new DateTime('2027-01-01 00:17:07');
 
         $this->assertHtml(
-            '<time class="time-until" data-ago-label="0m 0s ago" data-relative-time="until"'
+            '<time class="time-until" data-relative-time="until"'
             . ' title="2027-01-01 00:17:07" datetime="2027-01-01 00:17:07">on 2027-01</time>',
             new TimeUntil($eventTime, new DateTime('2026-03-17 14:17:07'))
         );
 
         $this->assertHtml(
-            '<time class="time-until" data-ago-label="0m 0s ago" data-relative-time="until"'
+            '<time class="time-until" data-relative-time="until"'
             . ' title="2027-01-01 00:17:07" datetime="2027-01-01 00:17:07">in 1d 10h</time>',
             new TimeUntil($eventTime, new DateTime('2026-12-30 14:17:07'))
         );
 
         $this->assertHtml(
-            '<time class="time-until" data-ago-label="0m 0s ago" data-relative-time="until"'
+            '<time class="time-until" data-relative-time="until"'
             . ' title="2027-01-01 00:17:07" datetime="2027-01-01 00:17:07">on Jan 1 00:17</time>',
             new TimeUntil($eventTime, new DateTime('2026-12-31 14:17:07'))
         );
@@ -155,7 +155,7 @@ HTML;
     public function testFormatWithPastDaysAndHoursNegatesTime(): void
     {
         $html = <<<'HTML'
-<time class="time-until" data-ago-label="0m 0s ago" data-relative-time="until"
+<time class="time-until" data-relative-time="until"
       title="2026-03-17 14:17:07" datetime="2026-03-17 14:17:07">in -1d 12h</time>
 HTML;
 
@@ -168,7 +168,7 @@ HTML;
     public function testRenderIgnoresFormatter(): void
     {
         $html = <<<'HTML'
-<time class="time-until" data-ago-label="0m 0s ago" data-relative-time="until"
+<time class="time-until" data-relative-time="until"
       title="2026-03-17 15:17:07" datetime="2026-03-17 15:17:07">at 15:17</time>
 HTML;
 


### PR DESCRIPTION
[icingadb-web](https://github.com/Icinga/icingadb-web/pull/1322) will not need the `data-ago-label` to switch from absolute to relative, so there is no longer a reason to add it on all `Time` elements.
It is now only added for the `TimeUntil` elements that need it.