### PR TITLE
Fix animation of appended relative time elements

### DIFF
--- a/asset/js/RelativeTime.js
+++ b/asset/js/RelativeTime.js
@@ -46,6 +46,10 @@ define(function () {
         }
 
         updateElement(element) {
+            if (element.hidden) {
+                return;
+            }
+
             const relativeTimeAgo = this.getType(element);
             if (relativeTimeAgo === 'ago' || relativeTimeAgo === 'since') {
                 const diffSeconds = this.getTimeDifferenceInSeconds(element);

--- a/asset/js/RelativeTime.js
+++ b/asset/js/RelativeTime.js
@@ -8,7 +8,20 @@ define(function () {
 
         constructor(timezone) {
             this.timezone = timezone;
-            this._trackedElements = new Set();
+            /**
+             * Walked by tick() to update the text on each element
+             *
+             * @type {Set<WeakRef<Element>>}
+             * @private
+             */
+            this._refsToUpdate = new Set();
+            /**
+             * Checked by scan() before adding to _refsToUpdate, to avoid tracking the same element twice
+             *
+             * @type {WeakSet<Element>}
+             * @private
+             */
+            this._knownElements = new WeakSet();
             this._timer = null;
         }
 
@@ -19,7 +32,10 @@ define(function () {
             }
 
             elements.forEach((el) => {
-                this._trackedElements.add(new WeakRef(el));
+                if (! this._knownElements.has(el)) {
+                    this._knownElements.add(el);
+                    this._refsToUpdate.add(new WeakRef(el));
+                }
             });
 
             if (! this._timer) {
@@ -28,12 +44,12 @@ define(function () {
         }
 
         tick() {
-            this._trackedElements.forEach((ref) => {
+            this._refsToUpdate.forEach((ref) => {
                 const el = ref.deref();
                 if (el) {
                     this.updateElement(el);
                 } else {
-                    this._trackedElements.delete(ref);
+                    this._refsToUpdate.delete(ref);
                 }
             })
         }

--- a/asset/js/behavior/RelativeTimeBehavior.js
+++ b/asset/js/behavior/RelativeTimeBehavior.js
@@ -27,7 +27,7 @@
             }
 
             onTimeRendered(event) {
-                if (event.currentTarget === event.target) {
+                if (event.target.closest('.container') === event.currentTarget) {
                     event.data.self._relativeTime.scan(event.target);
                 }
             }


### PR DESCRIPTION
fixes: #372 

To ensure `scan()` is run on appended content, it is now called only when the event has reached the container that is closest the its origin.
While working on this I noticed that the `Set` of `WeakRefs` used by `RelativeTime` stacked up several `WeakRefs` pointing to the same element when a container with known elements was rescanned, so I added `WeakSet` which is used by `scan` to prevent duplicates.


As suggested in https://github.com/Icinga/icingadb-web/pull/1322#pullrequestreview-4168528222 hidden elements are no longer animated, though this causes elements that become visible again to show an outdated value until the next tick.