### PR TITLE
`CopyToClipboard`: Preserve inline layout of visually hidden labels

### DIFF
--- a/asset/js/widget/CopyToClipboard.js
+++ b/asset/js/widget/CopyToClipboard.js
@@ -17,7 +17,7 @@ define(["../notjQuery"], function ($) {
             let copyText;
 
             if (clipboardSource) {
-                copyText = clipboardSource.innerText;
+                copyText = this.collectText(clipboardSource);
             } else {
                 throw new Error('Clipboard source is required but not provided');
             }
@@ -42,6 +42,31 @@ define(["../notjQuery"], function ($) {
 
             event.stopPropagation();
             event.preventDefault();
+        }
+
+        collectText(node)
+        {
+            let text = '';
+
+            for (const child of node.childNodes) {
+                if (child.nodeType === Node.TEXT_NODE) {
+                    text += child.nodeValue;
+                } else if (child.nodeType === Node.ELEMENT_NODE) {
+                    if (child.tagName === 'BR') {
+                        text += '\n';
+                        continue;
+                    }
+
+                    const style = window.getComputedStyle(child);
+                    if (style.display === 'none' || style.visibility === 'hidden') {
+                        continue;
+                    }
+
+                    text += this.collectText(child);
+                }
+            }
+
+            return text;
         }
     }
 


### PR DESCRIPTION
Switch from `Element.innerText` to a DOM walk that concatenates text node contents directly. `innerText` is rendering-aware and inserts a newline around any element it considers block-level, including `sr-only` content.

`<br>` is converted to `\n` and elements hidden via `display: none` /
`visibility: hidden` are skipped, so script/style content is not copied.

This is otherwise functionally identical to `Range.toString()` on `selectNodeContents` (see Icinga/icingadb-web#1366).