### PR TITLE
js: Add and utilize function `isSpecialKeypress`

### DIFF
--- a/asset/js/functions.js
+++ b/asset/js/functions.js
@@ -1,0 +1,21 @@
+(function (root, factory) {
+    "use strict";
+
+    if (typeof define === "function" && define.icinga) {
+        define(["exports"], factory);
+    } else {
+        factory(root.iplWebFunctions = root.iplWebFunctions || {});
+    }
+}(self, function (exports) {
+    /**
+     * Checks if the given keyboard event represents a special key press.
+     *
+     * @param {KeyboardEvent} event - The keyboard event to check.
+     * @returns {boolean} True if the event represents a special key press, false otherwise.
+     */
+    function isSpecialKeyPress(event) {
+        return event.key.length > 1 || event.ctrlKey || event.metaKey;
+    }
+
+    exports.isSpecialKeyPress = isSpecialKeyPress;
+}));

--- a/asset/js/widget/BaseInput.js
+++ b/asset/js/widget/BaseInput.js
@@ -1,4 +1,4 @@
-define(["../notjQuery", "Completer"], function ($, Completer) {
+define(["../notjQuery", "../functions", "Completer"], function ($, functions, Completer) {
 
     "use strict";
 
@@ -803,7 +803,7 @@ define(["../notjQuery", "Completer"], function ($, Completer) {
             let input = event.target;
             let termIndex = Number(input.parentNode.dataset.index);
 
-            if (this.hasSyntaxError(input) && ! (/[A-Z]/.test(event.key.charAt(0)) || event.ctrlKey || event.metaKey)) {
+            if (this.hasSyntaxError(input) && ! functions.isSpecialKeyPress(event)) {
                 // Clear syntax error flag if the user types entirely new input after having selected the entire input
                 // (This way the input isn't empty but switches from input to input immediately, causing the clearing
                 // in onInput to not work)

--- a/asset/js/widget/Completer.js
+++ b/asset/js/widget/Completer.js
@@ -695,18 +695,6 @@ define(["../notjQuery"], function ($) {
                         event.preventDefault();
                         this.moveToSuggestion();
                     }
-
-                    break;
-                default:
-                    if (/[A-Z]/.test(event.key.charAt(0)) || event.key === '"') {
-                        // Ignore control keys not resulting in new input data
-                        break;
-                    }
-
-                    let typedSuggestion = this.termSuggestions.querySelector(`[value="${ event.key }"]`);
-                    if (typedSuggestion !== null) {
-                        this.hideSuggestions();
-                    }
             }
         }
 

--- a/asset/js/widget/FilterInput.js
+++ b/asset/js/widget/FilterInput.js
@@ -1,4 +1,4 @@
-define(["../notjQuery", "BaseInput"], function ($, BaseInput) {
+define(["../notjQuery", "../functions", "BaseInput"], function ($, functions, BaseInput) {
 
     "use strict";
 
@@ -1350,7 +1350,7 @@ define(["../notjQuery", "BaseInput"], function ($, BaseInput) {
             } else if (input.selectionStart !== input.selectionEnd) {
                 // In case the user selected a range of text, do nothing
                 return;
-            } else if (/[A-Z]/.test(event.key.charAt(0)) || event.ctrlKey || event.metaKey) {
+            } else if (functions.isSpecialKeyPress(event)) {
                 // Ignore control keys not resulting in new input data
                 // TODO: Remove this and move the entire block into `onInput`
                 //       once Safari supports `InputEvent.data`


### PR DESCRIPTION
This is a way better implementation instead of just checking whether the pressed key's label starts with an uppercase char. (e.g. `Escape`) Problem is, uppercase single chars also match…

This could previously be observed when trying to type a value inside an operator input in the search bar. Normally this switches to the value input automatically, but an uppercase char was tried to identify as operator.

In the `Completer` implementation this uncovered dead code on the other hand. `onKeyPress` seems to have had the job to hide the suggestions in case the user typed one manually. Upon testing this now with an corrected check (`event.key` alone does not match a suggestion as it's only single char) this worked but the suggestions appeared immediately again. I've removed it now as it was broken prior and doesn't make any sense either nowadays, suggestions need to be always visible in order to confirm the validity of the input.