### PR TITLE
Handle search suggestions errors

### DIFF
--- a/src/Control/SearchBar/Suggestions.php
+++ b/src/Control/SearchBar/Suggestions.php
@@ -220,18 +220,13 @@ abstract class Suggestions extends BaseHtmlElement
         $this->prependHtml(new HtmlElement('li', Attributes::create(['class' => 'default']), $button));
     }
 
-    protected function assemble()
+    /**
+     * Assemble the list content
+     *
+     * @return bool Whether the default suggestion should be hidden or not
+     */
+    protected function assembleSuggestions(): bool
     {
-        if ($this->failureMessage !== null) {
-            $this->addHtml(new HtmlElement(
-                'li',
-                Attributes::create(['class' => 'failure-message']),
-                new HtmlElement('em', null, Text::create(t('Can\'t search:'))),
-                Text::create($this->failureMessage)
-            ));
-            return;
-        }
-
         if ($this->data === null) {
             $data = [];
         } elseif ($this->data instanceof Paginatable) {
@@ -291,8 +286,28 @@ abstract class Suggestions extends BaseHtmlElement
             $this->addHtml(new HtmlElement('li', null, $button));
         }
 
-        if ($this->hasMore($data, self::DEFAULT_LIMIT)) {
-            $this->getAttributes()->add('class', 'has-more');
+        return $noDefault ?? false;
+    }
+
+    protected function assemble()
+    {
+        if ($this->failureMessage === null) {
+            try {
+                $noDefault = $this->assembleSuggestions();
+            } catch (SearchException $e) {
+                $this->failureMessage = $e->getMessage();
+                $this->setContent(null);
+            }
+        }
+
+        if ($this->failureMessage !== null) {
+            $this->addHtml(new HtmlElement(
+                'li',
+                Attributes::create(['class' => 'failure-message']),
+                new HtmlElement('em', null, Text::create(t('Can\'t search:'))),
+                Text::create($this->failureMessage)
+            ));
+            return;
         }
 
         if ($this->type === 'column' && ! $this->isEmpty() && ! $this->getFirst('li')->getAttributes()->has('class')) {

--- a/src/FormElement/SearchSuggestions.php
+++ b/src/FormElement/SearchSuggestions.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Web\FormElement;
 
+use Exception;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlElement;
@@ -21,6 +22,9 @@ class SearchSuggestions extends BaseHtmlElement
 
     /** @var Traversable */
     protected $provider;
+
+    /** @var ?string */
+    protected ?string $failureMessage = null;
 
     /** @var ?callable */
     protected $groupingCallback;
@@ -54,6 +58,20 @@ class SearchSuggestions extends BaseHtmlElement
     public function __construct(Traversable $provider)
     {
         $this->provider = $provider;
+    }
+
+    /**
+     * Show a failure message
+     *
+     * @param ?string $message
+     *
+     * @return $this
+     */
+    public function showFailureMessage(?string $message)
+    {
+        $this->failureMessage = $message;
+
+        return $this;
     }
 
     /**
@@ -222,7 +240,7 @@ class SearchSuggestions extends BaseHtmlElement
         return $this;
     }
 
-    protected function assemble(): void
+    protected function assembleSuggestions(): void
     {
         $groupingCallback = $this->getGroupingCallback();
         if ($groupingCallback) {
@@ -276,6 +294,28 @@ class SearchSuggestions extends BaseHtmlElement
                     )
                 );
             }
+        }
+    }
+
+    protected function assemble(): void
+    {
+        if ($this->failureMessage === null) {
+            try {
+                $this->assembleSuggestions();
+            } catch (Exception $e) {
+                $this->failureMessage = $e->getMessage();
+                $this->setContent(null);
+            }
+        }
+
+        if ($this->failureMessage !== null) {
+            $this->addHtml(new HtmlElement(
+                'li',
+                Attributes::create(['class' => 'failure-message']),
+                new HtmlElement('em', null, Text::create($this->translate('Can\'t search:'))),
+                Text::create($this->failureMessage)
+            ));
+            return;
         }
 
         if ($this->isEmpty()) {

--- a/src/FormElement/SearchSuggestions.php
+++ b/src/FormElement/SearchSuggestions.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Web\FormElement;
 
+use ArrayIterator;
 use Exception;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
@@ -10,7 +11,6 @@ use ipl\Html\Text;
 use ipl\Html\ValidHtml;
 use ipl\I18n\Translation;
 use Psr\Http\Message\ServerRequestInterface;
-use Traversable;
 
 use function ipl\Stdlib\yield_groups;
 
@@ -20,8 +20,8 @@ class SearchSuggestions extends BaseHtmlElement
 
     protected $tag = 'ul';
 
-    /** @var Traversable */
-    protected $provider;
+    /** @var iterable */
+    protected iterable $provider;
 
     /** @var ?string */
     protected ?string $failureMessage = null;
@@ -53,9 +53,9 @@ class SearchSuggestions extends BaseHtmlElement
      *
      * Any excess key is also transferred to the client, but currently unused.
      *
-     * @param Traversable $provider
+     * @param iterable $provider
      */
-    public function __construct(Traversable $provider)
+    public function __construct(iterable $provider = [])
     {
         $this->provider = $provider;
     }
@@ -244,7 +244,12 @@ class SearchSuggestions extends BaseHtmlElement
     {
         $groupingCallback = $this->getGroupingCallback();
         if ($groupingCallback) {
-            $provider = yield_groups($this->provider, $groupingCallback);
+            $iterator = $this->provider;
+            if (is_array($iterator)) {
+                $iterator = new ArrayIterator($iterator);
+            }
+
+            $provider = yield_groups($iterator, $groupingCallback);
         } else {
             $provider = ['' => $this->provider];
         }


### PR DESCRIPTION
`\ipl\Web\Control\SearchBar\Suggestions` now catch `\ipl\Web\Control\SearchBar\SearchException` during assembly. Also, an unused CSS class `has-more` is not added anymore, as the initially planned pagination was never implemented and the refactor now made it unworthy to keep.

`\ipl\Web\FormElement\SearchSuggestions`'s constructor argument is now optional and a setter to show a failure message is added. In addition to that, it catches `\Exception` during assembly and uses it to indicate a failure on its own.