### PR TITLE
Introduce `DisplayFormElement` for embedding HTML in `CompatForm`

### DIFF
--- a/asset/css/compat.less
+++ b/asset/css/compat.less
@@ -147,3 +147,9 @@ form.icinga-form .suggestion-element-group {
     }
   }
 }
+
+// Display form element styles
+form.icinga-form .control-group > .display-form-element {
+  flex: 1 1 auto;
+  width: 0;
+}

--- a/src/Compat/DisplayFormElement.php
+++ b/src/Compat/DisplayFormElement.php
@@ -54,7 +54,7 @@ class DisplayFormElement extends BaseHtmlElement
             HtmlElement::create(
                 'div',
                 Attributes::create(['class' => 'control-label-group']),
-                $this->label ? HtmlElement::create('label', null, Text::create($this->label)) : null
+                $this->label !== null ? HtmlElement::create('label', null, Text::create($this->label)) : null
             )
         );
         $this->addHtml(

--- a/src/Compat/DisplayFormElement.php
+++ b/src/Compat/DisplayFormElement.php
@@ -7,6 +7,7 @@ namespace ipl\Web\Compat;
 
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
+use ipl\Html\Contract\HtmlElementInterface;
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
 use ipl\Html\ValidHtml;
@@ -61,9 +62,29 @@ class DisplayFormElement extends BaseHtmlElement
             HtmlElement::create('div', Attributes::create(['class' => 'display-form-element']), $this->content)
         );
         if ($this->description !== null) {
-            $this->addHtml(
-                new Icon('info-circle', Attributes::create(['class' => 'control-info', 'title' => $this->description]))
-            );
+            $elementDescription = new Icon('info-circle', Attributes::create([
+                'aria-hidden' => 'true',
+                'class'       => 'control-info',
+                'role'        => 'img',
+                'title'       => $this->description
+            ]));
+
+            if ($this->content instanceof HtmlElementInterface) {
+                if ($this->content->getAttributes()->has('id')) {
+                    $elementId = $this->content->getAttributes()->get('id')->getValue();
+                } else {
+                    $elementId = uniqid();
+                    $this->content->getAttributes()->set('id', $elementId);
+                }
+
+                $descriptionId = 'desc_' . $elementId;
+                $this->content->getAttributes()->add('aria-describedby', $descriptionId);
+
+                $elementDescription->getAttributes()->set('id', $descriptionId);
+                $elementDescription->getAttributes()->add('class', 'form-element-description');
+            }
+
+            $this->addHtml($elementDescription);
         }
     }
 }

--- a/src/Compat/DisplayFormElement.php
+++ b/src/Compat/DisplayFormElement.php
@@ -60,7 +60,7 @@ class DisplayFormElement extends BaseHtmlElement
         $this->addHtml(
             HtmlElement::create('div', Attributes::create(['class' => 'display-form-element']), $this->content)
         );
-        if ($this->description) {
+        if ($this->description !== null) {
             $this->addHtml(
                 new Icon('info-circle', Attributes::create(['class' => 'control-info', 'title' => $this->description]))
             );

--- a/src/Compat/DisplayFormElement.php
+++ b/src/Compat/DisplayFormElement.php
@@ -7,7 +7,6 @@ namespace ipl\Web\Compat;
 
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
-use ipl\Html\Contract\HtmlElementInterface;
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
 use ipl\Html\ValidHtml;
@@ -62,29 +61,9 @@ class DisplayFormElement extends BaseHtmlElement
             HtmlElement::create('div', Attributes::create(['class' => 'display-form-element']), $this->content)
         );
         if ($this->description !== null) {
-            $elementDescription = new Icon('info-circle', Attributes::create([
-                'aria-hidden' => 'true',
-                'class'       => 'control-info',
-                'role'        => 'img',
-                'title'       => $this->description
-            ]));
-
-            if ($this->content instanceof HtmlElementInterface) {
-                if ($this->content->getAttributes()->has('id')) {
-                    $elementId = $this->content->getAttributes()->get('id')->getValue();
-                } else {
-                    $elementId = uniqid();
-                    $this->content->getAttributes()->set('id', $elementId);
-                }
-
-                $descriptionId = 'desc_' . $elementId;
-                $this->content->getAttributes()->add('aria-describedby', $descriptionId);
-
-                $elementDescription->getAttributes()->set('id', $descriptionId);
-                $elementDescription->getAttributes()->add('class', 'form-element-description');
-            }
-
-            $this->addHtml($elementDescription);
+            $this->addHtml(
+                new Icon('info-circle', Attributes::create(['class' => 'control-info', 'title' => $this->description]))
+            );
         }
     }
 }

--- a/src/Compat/DisplayFormElement.php
+++ b/src/Compat/DisplayFormElement.php
@@ -1,0 +1,69 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace ipl\Web\Compat;
+
+use ipl\Html\Attributes;
+use ipl\Html\BaseHtmlElement;
+use ipl\Html\HtmlElement;
+use ipl\Html\Text;
+use ipl\Html\ValidHtml;
+use ipl\Web\Widget\Icon;
+
+/**
+ * This is an element that integrates {@see ValidHtml} into an IPL Web {@see CompatForm}.
+ *
+ * The html will be rendered as follows:
+ * <pre>
+ * <div class='control-group'>
+ *     <div class='control-label-group'>
+ *         <!-- if label is set -->
+ *         <label>$this->label</label>
+ *     </div>
+ *     <div class='display-form-element'>
+ *         $this->content
+ *     </div>
+ *     <!-- if description is set -->
+ *     <i class="icon fa-info-circle control-info fa" role="image" title="$this->description"></i>
+ * </div>
+ * </pre>
+ */
+class DisplayFormElement extends BaseHtmlElement
+{
+    protected $tag = 'div';
+
+    protected $defaultAttributes = ['class' => 'control-group'];
+
+    /**
+     * @param ValidHtml $content The element to add to the form
+     * @param ?string $label The label to render in the control-label-group element
+     * @param ?string $description The description to show for the element
+     */
+    public function __construct(
+        protected ValidHtml $content,
+        protected ?string $label = null,
+        protected ?string $description = null
+    ) {
+    }
+
+    protected function assemble(): void
+    {
+        $this->addHtml(
+            HtmlElement::create(
+                'div',
+                Attributes::create(['class' => 'control-label-group']),
+                $this->label ? HtmlElement::create('label', null, Text::create($this->label)) : null
+            )
+        );
+        $this->addHtml(
+            HtmlElement::create('div', Attributes::create(['class' => 'display-form-element']), $this->content)
+        );
+        if ($this->description) {
+            $this->addHtml(
+                new Icon('info-circle', Attributes::create(['class' => 'control-info', 'title' => $this->description]))
+            );
+        }
+    }
+}


### PR DESCRIPTION
Allows arbitrary `ValidHtml` content to be placed inside a `CompatForm` control group, complete with an optional label and description icon. The companion CSS rule ensures the wrapper div stretches to fill available horizontal space within the flex layout.

This is used for the new two-factor auth feature in Icinga Web.