### PR TITLE
Use stdlib `Str::isEmpty()` to check if a string is visually empty

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "ipl/i18n": ">=1.0.0",
     "ipl/orm": ">=0.8.0",
     "ipl/scheduler": ">=0.3.0",
-    "ipl/stdlib": ">=0.15.0",
+    "ipl/stdlib": ">=0.16.0",
     "psr/http-message": "^1.1",
     "wikimedia/less.php": "^5.5"
   },

--- a/src/Widget/Callout.php
+++ b/src/Widget/Callout.php
@@ -7,6 +7,7 @@ use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
 use ipl\Html\ValidHtml;
+use ipl\Stdlib\Str;
 use ipl\Web\Common\CalloutType;
 
 /**
@@ -49,7 +50,7 @@ class Callout extends BaseHtmlElement
             'div',
             ['class' => 'callout-text'],
             [
-                $this->title === null || trim($this->title) === ''
+                Str::isEmpty($this->title)
                     ? null
                     : HtmlElement::create('strong', ['class' => 'callout-title'], Text::create($this->title)),
                 is_string($this->content) ? Text::create($this->content) : $this->content,

--- a/tests/Widget/CalloutTest.php
+++ b/tests/Widget/CalloutTest.php
@@ -73,6 +73,21 @@ HTML;
         $this->assertHtml($html, $callout);
     }
 
+    public function testCalloutWithEmptyUtf8Title(): void
+    {
+        $callout = new Callout(CalloutType::Error, 'Content', "\u{2000}");
+
+        $html = <<<'HTML'
+<div class="callout callout-type-error">
+    <i class="icon fa-circle-xmark fa"></i>
+    <div class="callout-text">
+        Content
+    </div>
+</div>
+HTML;
+        $this->assertHtml($html, $callout);
+    }
+
     public function testCalloutValidHtmlContent(): void
     {
         $callout = new Callout(


### PR DESCRIPTION
Str::isEmpty() also handles Unicode whitespace, making the check visually empty rather than just ASCII-empty. Adds a test for a Unicode whitespace-only title.

- requires Icinga/ipl-stdlib#77