### PR TITLE
PrimaryButtonDecorator: Only mark a single button primary

### DIFF
--- a/src/Compat/FormDecorator/PrimaryButtonDecorator.php
+++ b/src/Compat/FormDecorator/PrimaryButtonDecorator.php
@@ -6,16 +6,21 @@ use ipl\Html\Attribute;
 use ipl\Html\Contract\DecorationResult;
 use ipl\Html\Contract\Form;
 use ipl\Html\Contract\FormDecoration;
-use ipl\Html\Contract\FormSubmitElement;
+use ipl\Html\Form as iplForm;
 
+/**
+ * Marks the form’s submit button as primary (adds the "btn-primary" CSS class).
+ *
+ * Note: This decorator only applies to {@see \ipl\Html\Form} instances because it relies on
+ * the submit-button tracking provided by that implementation.
+ */
 class PrimaryButtonDecorator implements FormDecoration
 {
     public function decorateForm(DecorationResult $result, Form $form): void
     {
-        foreach ($form->getElements() as $element) {
-            if ($element instanceof FormSubmitElement) {
-                $element->getAttributes()->addAttribute(new Attribute('class', 'btn-primary'));
-            }
+        if ($form instanceof iplForm && $form->hasSubmitButton()) {
+            $form->getSubmitButton()->getAttributes()
+                ->addAttribute(new Attribute('class', 'btn-primary'));
         }
     }
 }

--- a/tests/Compat/FormDecorator/PrimaryButtonDecoratorTest.php
+++ b/tests/Compat/FormDecorator/PrimaryButtonDecoratorTest.php
@@ -16,13 +16,12 @@ class PrimaryButtonDecoratorTest extends TestCase
         $this->decorator = new PrimaryButtonDecorator();
     }
 
-    public function testEveryButtonIsMarkedAsPrimaryButton(): void
+    public function testOnlyTheFirstSubmitButtonIsMarkedPrimaryByDefault(): void
     {
         $form = (new CompatForm())
             ->addElement('submit', 'btn-1')
             ->addElement('submit', 'btn-2', ['class' => 'test'])
-            ->addElement('submit', 'btn-3', ['class' => 'btn-remove'])
-            ->addElement('submit', 'btn-4', ['class' => 'btn-primary']);
+            ->addElement('submit', 'btn-3', ['class' => 'btn-remove']);
 
         $this->decorator->decorateForm(new FormElementDecorationResult(), $form);
 
@@ -32,18 +31,40 @@ class PrimaryButtonDecoratorTest extends TestCase
         );
 
         $this->assertSame(
+            'class="test"',
+            $form->getElement('btn-2')->getAttributes()->get('class')->render()
+        );
+
+        $this->assertSame(
+            'class="btn-remove"',
+            $form->getElement('btn-3')->getAttributes()->get('class')->render()
+        );
+    }
+
+    public function testAnExplicitlySetSubmitButtonIsMarkedPrimary(): void
+    {
+        $form = (new CompatForm())
+            ->addElement('submit', 'btn-1')
+            ->addElement('submit', 'btn-2', ['class' => 'test'])
+            ->addElement('submit', 'btn-3', ['class' => 'btn-remove']);
+
+        $form->setSubmitButton($form->getElement('btn-2'));
+
+        $this->decorator->decorateForm(new FormElementDecorationResult(), $form);
+
+        $this->assertSame(
+            '',
+            $form->getElement('btn-1')->getAttributes()->get('class')->render()
+        );
+
+        $this->assertSame(
             'class="test btn-primary"',
             $form->getElement('btn-2')->getAttributes()->get('class')->render()
         );
 
         $this->assertSame(
-            'class="btn-remove btn-primary"',
+            'class="btn-remove"',
             $form->getElement('btn-3')->getAttributes()->get('class')->render()
-        );
-
-        $this->assertSame(
-            'class="btn-primary btn-primary"',
-            $form->getElement('btn-4')->getAttributes()->get('class')->render()
         );
     }
 


### PR DESCRIPTION
It applies now only to implementations of `\ipl\Html\Form`. But the reality was that it previoulsy relied on `\ipl\Html\Contract\FormElements` instead which the method's interface didn't guarantee either.

closes #388