### PR TITLE
Fix long error messages in the `SearchEditor`

### DIFF
--- a/asset/css/search-editor.less
+++ b/asset/css/search-editor.less
@@ -59,16 +59,14 @@
     .rounded-corners(0 .4em .4em 0);
   }
 
-  .search-error {
-    input:invalid {
-      background: var(--search-term-invalid-bg, @search-term-invalid-bg);
-      color: var(--search-term-invalid-color, @search-term-invalid-color);
-    }
+  fieldset:has(.search-errors) input:invalid {
+    background: var(--search-term-invalid-bg, @search-term-invalid-bg);
+    color: var(--search-term-invalid-color, @search-term-invalid-color);
+  }
 
-    .search-errors {
-      color: var(--search-editor-error-color, @search-editor-error-color);
-      font-weight: bold;
-    }
+  .search-errors {
+    color: var(--search-editor-error-color, @search-editor-error-color);
+    font-weight: bold;
   }
 
   li > select:not([multiple]) {
@@ -139,6 +137,7 @@
   fieldset {
     display: flex;
     flex: 1 1 auto;
+    flex-wrap: wrap;
     margin: 0;
     padding: 0;
 
@@ -150,14 +149,14 @@
     > :not(:first-child) {
       margin-left: .1em;
     }
+
+    .search-errors {
+      margin-left: .5em;
+    }
   }
 
   input, button, select {
     height: 28/12em; // Target Pixels @ default font size / default font size
-  }
-
-  .search-errors {
-    margin-left: .5em;
   }
 
   i.drag-initiator {

--- a/src/Control/SearchEditor.php
+++ b/src/Control/SearchEditor.php
@@ -4,15 +4,15 @@ namespace ipl\Web\Control;
 
 use ipl\Html\Attributes;
 use ipl\Html\Form;
-use ipl\Html\FormDecorator\CallbackDecorator;
+use ipl\Html\FormElement\FieldsetElement;
 use ipl\Html\HtmlDocument;
 use ipl\Html\HtmlElement;
-use ipl\Html\Text;
 use ipl\I18n\Translation;
 use ipl\Stdlib\Events;
 use ipl\Stdlib\Filter;
 use ipl\Web\Compat\StyleWithNonce;
 use ipl\Web\Control\SearchBar\SearchException;
+use ipl\Web\Control\SearchEditor\ConditionErrorsDecorator;
 use ipl\Web\Filter\Parser;
 use ipl\Web\Filter\QueryString;
 use ipl\Web\Filter\Renderer;
@@ -500,32 +500,6 @@ class SearchEditor extends Form
         $columnInput->getAttributes()->registerAttributeCallback('data-suggest-url', function () {
             return (string) $this->getSuggestionUrl();
         });
-        (new CallbackDecorator(function ($element) {
-            $errors = new HtmlElement('ul', Attributes::create(['class' => 'search-errors']));
-
-            foreach ($element->getMessages() as $message) {
-                $errors->addHtml(new HtmlElement('li', null, Text::create($message)));
-            }
-
-            if (! $errors->isEmpty()) {
-                if (trim($element->getValue())) {
-                    $element->getAttributes()->add(
-                        'pattern',
-                        sprintf(
-                            '^\s*(?!%s\b).*\s*$',
-                            $element->getValue()
-                        )
-                    );
-                }
-
-                $element->prependWrapper(new HtmlElement(
-                    'div',
-                    Attributes::create(['class' => 'search-error']),
-                    $element,
-                    $errors
-                ));
-            }
-        }))->decorate($columnInput);
 
         $columnFakeInput = $this->createElement('hidden', $identifier . '-column-search', [
             'value' => static::FAKE_COLUMN
@@ -543,6 +517,13 @@ class SearchEditor extends Form
                     $this->emit(static::ON_VALIDATE_COLUMN, [$condition]);
                 } catch (SearchException $e) {
                     $columnInput->addMessage($e->getMessage());
+                    if (trim($columnInput->getValue())) {
+                        $columnInput->getAttributes()->add(
+                            'pattern',
+                            sprintf('^\s*(?!%s\b).*\s*$', $columnInput->getValue())
+                        );
+                    }
+
                     return false;
                 }
 
@@ -586,15 +567,19 @@ class SearchEditor extends Form
         $this->registerElement($operatorInput);
         $this->registerElement($valueInput);
 
-        return new HtmlElement(
-            'fieldset',
-            Attributes::create(['name' => $identifier . '-']),
-            $columnInput,
-            $columnFakeInput,
-            $columnSearchInput,
-            $operatorInput,
-            $valueInput
-        );
+        $fieldset = (new FieldsetElement($identifier . '-'))
+            ->addHtml(
+                $columnInput,
+                $columnFakeInput,
+                $columnSearchInput,
+                $operatorInput,
+                $valueInput
+            )
+            ->setDecorators(['errors' => new ConditionErrorsDecorator()]);
+
+        $this->decorate($fieldset);
+
+        return $fieldset;
     }
 
     protected function assemble()

--- a/src/Control/SearchEditor/ConditionErrorsDecorator.php
+++ b/src/Control/SearchEditor/ConditionErrorsDecorator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ipl\Web\Control\SearchEditor;
+
+use ipl\Html\Attributes;
+use ipl\Html\Contract\DecorationResult;
+use ipl\Html\Contract\FormElement;
+use ipl\Html\Contract\FormElementDecoration;
+use ipl\Html\Contract\MutableHtml;
+use ipl\Html\HtmlElement;
+use ipl\Html\Text;
+
+class ConditionErrorsDecorator implements FormElementDecoration
+{
+    /**
+     * Collects a condition fieldset's child element errors into one `.search-errors` list
+     */
+    public function decorateFormElement(DecorationResult $result, FormElement $formElement): void
+    {
+        if (! $formElement instanceof MutableHtml) {
+            return;
+        }
+
+        $errors = new HtmlElement('ul', Attributes::create(['class' => 'search-errors']));
+
+        foreach ($formElement->getContent() as $element) {
+            if ($element instanceof FormElement) {
+                foreach ($element->getMessages() as $message) {
+                    $errors->addHtml(new HtmlElement('li', null, Text::create($message)));
+                }
+            }
+        }
+
+        if (! $errors->isEmpty()) {
+            $formElement->addHtml($errors);
+        }
+    }
+}


### PR DESCRIPTION
fix #382 
Ensure long validation messages span across the entire condition instead of pushing elements away.

<img width="1247" height="267" alt="Screenshot from 2026-06-24 08-50-13" src="https://github.com/user-attachments/assets/4dca5c09-c39e-4be9-86e7-286fdd7acf5d" />
