### PR TITLE
CsrfCounterMeasure: skip Sec-Fetch-Site check for safe HTTP methods

### DIFF
--- a/src/Common/CsrfCounterMeasure.php
+++ b/src/Common/CsrfCounterMeasure.php
@@ -134,13 +134,21 @@ trait CsrfCounterMeasure
      * Get whether the request is safe from CSRF based on the Sec-Fetch-Site header
      *
      * Returns true if the header indicates a same-origin request or a user-originated operation (e.g. typing a URL),
-     * both of which cannot be forged by a cross-site attacker. Returns null if the header is absent,
-     * in which case a CSRF token must be validated. False indicates a cross-site request.
+     * both of which cannot be forged by a cross-site attacker. Returns false if the header indicates a cross-site
+     * request. Returns null in two cases where a token-based fallback should be used instead: when the request uses an
+     * RFC 9110 safe method (GET, HEAD, OPTIONS, TRACE), which cannot carry CSRF side effects by definition, or when
+     * the header is absent, indicating a legacy browser that must be validated via the CSRF token.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc9110#section-9.2.1
      *
      * @return ?bool
      */
     protected function requestIsSafe(): ?bool
     {
+        if (in_array($_SERVER['REQUEST_METHOD'] ?? null, ['GET', 'HEAD', 'OPTIONS', 'TRACE'], true)) {
+            return null;
+        }
+
         return match ($_SERVER['HTTP_SEC_FETCH_SITE'] ?? null) {
             'same-origin' => true, // same scheme, host and port
             'none'        => true, // a user-originated operation

--- a/tests/Common/CsrfCounterMeasureTest.php
+++ b/tests/Common/CsrfCounterMeasureTest.php
@@ -15,13 +15,13 @@ class CsrfCounterMeasureTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        unset($_SERVER['HTTP_SEC_FETCH_SITE']);
+        unset($_SERVER['HTTP_SEC_FETCH_SITE'], $_SERVER['REQUEST_METHOD']);
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
-        unset($_SERVER['HTTP_SEC_FETCH_SITE']);
+        unset($_SERVER['HTTP_SEC_FETCH_SITE'], $_SERVER['REQUEST_METHOD']);
     }
 
     public function testTokenCreation()
@@ -110,6 +110,43 @@ class CsrfCounterMeasureTest extends TestCase
         $this->expectExceptionMessage('Rejecting cross-site request');
 
         $this->makeForm()->callCreate('uniqueId');
+    }
+
+    public static function safeMethodProvider(): array
+    {
+        return [
+            'GET'     => ['GET'],
+            'HEAD'    => ['HEAD'],
+            'OPTIONS' => ['OPTIONS'],
+            'TRACE'   => ['TRACE'],
+        ];
+    }
+
+    #[DataProvider('safeMethodProvider')]
+    public function testCreateDoesNotThrowForSafeMethodWithCrossSiteHeader(string $method): void
+    {
+        $_SERVER['REQUEST_METHOD']      = $method;
+        $_SERVER['HTTP_SEC_FETCH_SITE'] = 'cross-site';
+
+        $this->makeForm()->callCreate('uniqueId');
+        $this->addToAssertionCount(1);
+    }
+
+    #[DataProvider('safeMethodProvider')]
+    public function testCreateReturnsTokenElementForSafeMethod(string $method): void
+    {
+        $_SERVER['REQUEST_METHOD']      = $method;
+        $_SERVER['HTTP_SEC_FETCH_SITE'] = 'cross-site';
+
+        $element = $this->makeForm()->callCreate('uniqueId');
+
+        // The token element must reject invalid values; a dummy element would accept them.
+        $element->setValue('garbage');
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Invalid CSRF token provided');
+
+        $element->isValid();
     }
 
     private function createElement(): FormElement


### PR DESCRIPTION
[RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#section-9.2.1) defines GET, HEAD, OPTIONS, and TRACE as safe methods: they must not cause side effects, so they cannot be exploited for CSRF. Previously, `requestIsSafe()` checked the Sec-Fetch-Site header unconditionally, which caused it to return false (and throw "Rejecting cross-site request") when a cross-origin GET navigation reached a form. This broke legitimate flows where an external service redirects the browser to a form. The redirect carries
`Sec-Fetch-Site: cross-site`, and the form assembly failed before the page could render.

For safe methods, `requestIsSafe()` now returns null, falling through to the token-based CSRF fallback. The token embedded in the rendered form still protects the subsequent POST submission.