### PR TITLE
Add `ViewModeSwitcher` control

### DIFF
--- a/asset/css/controls.less
+++ b/asset/css/controls.less
@@ -109,10 +109,10 @@
 /**
  The default layout of list controls in Icinga Web
 
- ┌────────────────────────────────────────────────────────────────┐
- │ .pagination-control               .limit-control .sort-control │
- │ <-------------------- .search-controls ----------------------> │
- └────────────────────────────────────────────────────────────────┘
+ ┌───────────────────────────────────────────────────────────────────────────────────┐
+ │ .pagination-control              .view-mode-switcher .limit-control .sort-control │
+ │ <---------------------------- .search-controls ---------------------------------> │
+ └───────────────────────────────────────────────────────────────────────────────────┘
  */
 .controls.default-layout {
   .box-shadow(0, 0, 0, 1px, @controls-separator-bg);
@@ -127,10 +127,12 @@
   }
 
   > .sort-control,
+  > .view-mode-switcher,
   > .limit-control {
     float: right;
   }
 
+  > .view-mode-switcher,
   > .limit-control {
     margin-right: .5em;
   }

--- a/asset/css/view-mode-switcher.less
+++ b/asset/css/view-mode-switcher.less
@@ -1,0 +1,42 @@
+.view-mode-switcher {
+  display: flex;
+
+  input {
+    display: none;
+  }
+
+  label {
+    color: var(--control-color, @control-color);
+    line-height: 1;
+    background: var(--default-input-bg, @default-input-bg);
+    padding: 14/16*.25em 14/16*.5em;
+    font-size: 16/12em;
+    height: 24/16em; // desired pixel height / font-size
+    cursor: pointer;
+
+    &:first-of-type {
+      border-top-left-radius: 0.25em;
+      border-bottom-left-radius: 0.25em;
+    }
+
+    &:last-of-type {
+      border-top-right-radius: 0.25em;
+      border-bottom-right-radius: 0.25em;
+    }
+
+    &:not(:last-of-type) {
+      border-right: 1px solid var(--default-input-hover-bg, @default-input-hover-bg);
+    }
+
+    i {
+      // fix height for Chrome
+      display: block;
+    }
+  }
+
+  input[checked] + label {
+    background-color: var(--control-color, @control-color);
+    color: var(--default-text-color-inverted, @default-text-color-inverted);
+    cursor: default;
+  }
+}

--- a/src/Common/Controls.php
+++ b/src/Common/Controls.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace ipl\Web\Common;
+
+use ipl\Html\Form;
+use ipl\Stdlib\Events;
+use ipl\Web\Control\ViewModeSwitcher;
+use ipl\Web\Url;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Provides factory methods to prepare reusable web controls and allows to handle their requests
+ *
+ * {@see static::handleControls()} can be called to call {@see Form::handleRequest()} for all Controls created by
+ * this trait.
+ */
+trait Controls
+{
+    use Events;
+
+    /** @var string Event emitted when the view mode has been changed */
+    public const ON_VIEW_MODE_CHANGE = 'view-mode-change';
+
+    /** @var string Event emmitted when the created {@see ViewModeSwitcher} is populated with a view mode */
+    public const ON_VIEW_MODE_SET = 'view-mode-set';
+
+    /** @var array<Form> Controls for which {@see self::handleControls()} must call {@see Form::handleRequest()} */
+    private array $trackedControls = [];
+
+    /**
+     * Redirect to the given Url
+     *
+     * @param Url|string $url
+     *
+     * @return never
+     */
+    abstract protected function redirectNow($url);
+
+    /**
+     * Create a {@see ViewModeSwitcher} control
+     *
+     * On {@see ViewModeSwitcher::ON_REQUEST} the created instance is populated with the view mode from the url
+     * and {@see static::ON_VIEW_MODE_SET} is emmitted.
+     *
+     * On {@see ViewModeSwitcher::ON_SUBMIT}, if the view mode was changed, {@see static::ON_VIEW_MODE_CHANGE}
+     * is emmitted with the {@see ViewModeSwitcher}, its previous view mode and a redirect url, which listeners
+     * may modify.
+     *
+     * @return ViewModeSwitcher
+     */
+    public function createViewModeSwitcher(): ViewModeSwitcher
+    {
+        $viewModeSwitcher = new ViewModeSwitcher();
+
+        $this->trackControl($viewModeSwitcher);
+
+        $viewModeSwitcher->on(
+            ViewModeSwitcher::ON_REQUEST,
+            function (
+                ServerRequestInterface $request,
+                ViewModeSwitcher $viewModeSwitcher
+            ) {
+                $viewModeSwitcher->populate([
+                    $viewModeSwitcher->getViewModeParam()
+                        => $request->getQueryParams()[$viewModeSwitcher->getViewModeParam()] ?? null
+                ]);
+
+                $this->emit(static::ON_VIEW_MODE_SET, [$viewModeSwitcher]);
+            }
+        );
+
+        $viewModeSwitcher->on(
+            ViewModeSwitcher::ON_SUBMIT,
+            function (
+                ViewModeSwitcher $viewModeSwitcher
+            ): void {
+                $previousViewModeName =
+                    $viewModeSwitcher->getRequest()->getQueryParams()[$viewModeSwitcher->getViewModeParam()]
+                    ?? $viewModeSwitcher->getDefaultViewMode()->getName();
+                $previousViewMode = $viewModeSwitcher->getViewModes()[$previousViewModeName];
+
+                if ($viewModeSwitcher->getViewMode()->getName() !== $previousViewMode->getName()) {
+                    $redirectUrl = Url::fromRequest();
+                    $this->emit(static::ON_VIEW_MODE_CHANGE, [$viewModeSwitcher, $previousViewMode, $redirectUrl]);
+                    $redirectUrl->setParam(
+                        $viewModeSwitcher->getViewModeParam(),
+                        $viewModeSwitcher->getViewMode()->getName()
+                    );
+                    $this->redirectNow($redirectUrl);
+                }
+            }
+        );
+
+        return $viewModeSwitcher;
+    }
+
+    /**
+     * Register the given control for lookup by {@see self::getTrackedControl()} and for {@see self::handleControls()}
+     *
+     * @param Form $control
+     *
+     * @return $this
+     */
+    protected function trackControl(Form $control): static
+    {
+        $this->trackedControls[] = $control;
+
+        return $this;
+    }
+
+    /**
+     * Get the tracked control of the given type
+     *
+     * @template TControl of Form
+     *
+     * @param class-string<TControl> $type
+     *
+     * @return ?TControl
+     */
+    protected function getTrackedControl(string $type): ?Form
+    {
+        foreach ($this->trackedControls as $control) {
+            if ($control instanceof $type) {
+                return $control;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Call {@see Form::handleRequest()} on every control in {@see self::$trackedControls}.
+     *
+     * @param ServerRequestInterface $request
+     *
+     * @return $this
+     */
+    protected function handleControls(ServerRequestInterface $request): static
+    {
+        foreach ($this->trackedControls as $control) {
+            $control->handleRequest($request);
+        }
+
+        return $this;
+    }
+}

--- a/src/Compat/CompatController.php
+++ b/src/Compat/CompatController.php
@@ -12,10 +12,13 @@ use ipl\Html\HtmlString;
 use ipl\Html\ValidHtml;
 use ipl\Orm\Query;
 use ipl\Stdlib\Contract\Paginatable;
+use ipl\Stdlib\Events;
 use ipl\Web\Control\LimitControl;
 use ipl\Web\Control\PaginationControl;
 use ipl\Web\Control\SearchBar;
 use ipl\Web\Control\SortControl;
+use ipl\Web\Control\ViewModeSwitcher;
+use ipl\Web\Control\ViewModeSwitcher\ViewMode;
 use ipl\Web\Layout\Content;
 use ipl\Web\Layout\Controls;
 use ipl\Web\Layout\Footer;
@@ -26,6 +29,8 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class CompatController extends Controller
 {
+    use Events;
+
     /** @var Content */
     protected $content;
 
@@ -244,6 +249,10 @@ class CompatController extends Controller
      *
      * This automatically shifts the limit URL parameter from {@link $params}.
      *
+     * If a {@see ViewModeSwitcher} is created using {@see \ipl\Web\Common\Controls::createViewModeSwitcher()}
+     * the default limit will automatically be set to the current {@see ViewMode::getPageSize()},
+     * unless an explicit limit is declared in the url.
+     *
      * @return LimitControl
      */
     public function createLimitControl(): LimitControl
@@ -253,6 +262,17 @@ class CompatController extends Controller
 
         $this->params->shift($limitControl->getLimitParam());
 
+        $this->on(
+        /** {@see \ipl\Web\Common\Controls::ON_VIEW_MODE_SET} */
+            'view-mode-set',
+            function (ViewModeSwitcher $viewModeSwitcher) use ($limitControl) {
+                if (! isset($this->getServerRequest()->getQueryParams()[$limitControl->getLimitParam()])) {
+                    $limit = $viewModeSwitcher->getViewMode()->getPageSize();
+                    $limitControl->setDefaultLimit($this->getPageSize($limit));
+                }
+            }
+        );
+
         return $limitControl;
     }
 
@@ -260,6 +280,13 @@ class CompatController extends Controller
      * Create and return the PaginationControl
      *
      * This automatically shifts the pagination URL parameters from {@link $params}.
+     *
+     * If a {@see ViewModeSwitcher} is created using {@see \ipl\Web\Common\Controls::createViewModeSwitcher()}
+     * the default page size will automatically be set to the current {@see ViewMode::getPageSize()},
+     * unless an explicit page size is declared in the url.
+     *
+     * When a change of view mode changes the page size, the current page is corrected so that the previously first
+     * element is always visible on the corrected page.
      *
      * @param Paginatable $paginatable
      *
@@ -273,6 +300,44 @@ class CompatController extends Controller
 
         $this->params->shift($paginationControl->getPageParam());
         $this->params->shift($paginationControl->getPageSizeParam());
+
+        $this->on(
+        /** {@see \ipl\Web\Common\Controls::ON_VIEW_MODE_SET} */
+            'view-mode-set',
+            function (ViewModeSwitcher $viewModeSwitcher) use ($paginationControl) {
+                if (! isset($this->getServerRequest()->getQueryParams()[$paginationControl->getPageSizeParam()])) {
+                    $limit = $viewModeSwitcher->getViewMode()->getPageSize();
+                    $paginationControl->setDefaultPageSize($this->getPageSize($limit))
+                        ->apply();
+                }
+            }
+        );
+
+        $this->on(
+        /** {@see \ipl\Web\Common\Controls::ON_VIEW_MODE_CHANGE} */
+            'view-mode-change',
+            function (
+                ViewModeSwitcher $viewModeSwitcher,
+                ViewMode $previousViewMode,
+                Url $redirectUrl
+            ) use ($paginationControl) {
+                if (
+                    ! isset($this->getServerRequest()->getQueryParams()[$paginationControl->getPageSizeParam()])
+                    && $viewModeSwitcher->getViewMode()->getName() !== $previousViewMode->getName()
+                ) {
+                    $previous = $previousViewMode->getPageSize();
+                    $new = $viewModeSwitcher->getViewMode()->getPageSize();
+
+                    $page = (int) floor((($paginationControl->getCurrentPageNumber() - 1) * $previous) / $new) + 1;
+
+                    if ($page > 1) {
+                        $redirectUrl->setParam($paginationControl->getPageParam(), $page);
+                    } else {
+                        $redirectUrl->remove($paginationControl->getPageParam());
+                    }
+                }
+            }
+        );
 
         return $paginationControl->apply();
     }

--- a/src/Compat/SearchControls.php
+++ b/src/Compat/SearchControls.php
@@ -7,8 +7,10 @@ use ipl\Html\Html;
 use ipl\Orm\Exception\InvalidRelationException;
 use ipl\Orm\Query;
 use ipl\Stdlib\Seq;
+use ipl\Web\Common\Controls;
 use ipl\Web\Control\SearchBar;
 use ipl\Web\Control\SearchEditor;
+use ipl\Web\Control\ViewModeSwitcher;
 use ipl\Web\Filter\QueryString;
 use ipl\Web\Url;
 use ipl\Stdlib\Filter;
@@ -63,6 +65,14 @@ trait SearchControls
             $redirectUrl->addParams($paramsToAdd);
         } else {
             $redirectUrl = $requestUrl->onlyWith($preserveParams);
+        }
+
+        /** If {@see Controls::createViewModeSwitcher()} was used, the view mode param must be removed form the url */
+        if (method_exists($this, 'getTrackedControl')) {
+            $viewModeSwitcher = $this->getTrackedControl(ViewModeSwitcher::class);
+            if ($viewModeSwitcher !== null) {
+                $this->params->shift($viewModeSwitcher->getViewModeParam());
+            }
         }
 
         $filter = QueryString::fromString((string) $this->params)

--- a/src/Control/ViewModeSwitcher.php
+++ b/src/Control/ViewModeSwitcher.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace ipl\Web\Control;
+
+use InvalidArgumentException;
+use ipl\Html\Attributes;
+use ipl\Html\Form;
+use ipl\Html\FormElement\HiddenElement;
+use ipl\Html\FormElement\InputElement;
+use ipl\Html\HtmlElement;
+use ipl\I18n\Translation;
+use ipl\Web\Common\FormUid;
+use ipl\Web\Control\ViewModeSwitcher\ViewMode;
+use LogicException;
+
+class ViewModeSwitcher extends Form
+{
+    use FormUid;
+    use Translation;
+
+    protected $defaultAttributes = [
+        'class' => 'view-mode-switcher',
+        'name' => 'view-mode-switcher'
+    ];
+
+    /** @var string Default view mode */
+    public const DEFAULT_VIEW_MODE = 'common';
+
+    /** @var string Default view mode param */
+    public const DEFAULT_VIEW_MODE_PARAM = 'view';
+
+    /** @var array<string, ViewMode> The available view modes, keyed by their name */
+    protected array $viewModes;
+
+    /** @var ?string Name of the default view mode */
+    protected ?string $defaultViewMode = null;
+
+    /** @var string */
+    protected $method = 'POST';
+
+    /** @var callable */
+    protected $protector;
+
+    protected string $viewModeParam = self::DEFAULT_VIEW_MODE_PARAM;
+
+    /**
+     * Create a view mode switcher providing the `minimal`, `common` and `detailed` view modes
+     */
+    public function __construct()
+    {
+        $this->setViewModes(
+            new ViewMode(
+                'minimal',
+                'minimal',
+                $this->translate('Minimal view active'),
+                $this->translate('Switch to minimal view'),
+                50
+            ),
+            new ViewMode(
+                'common',
+                'default',
+                $this->translate('Common view active'),
+                $this->translate('Switch to common view')
+            ),
+            new ViewMode(
+                'detailed',
+                'detailed',
+                $this->translate('Detailed view active'),
+                $this->translate('Switch to detailed view')
+            )
+        );
+    }
+
+    /**
+     * Get the available view modes
+     *
+     * @return array<string, ViewMode>
+     */
+    public function getViewModes(): array
+    {
+        return $this->viewModes;
+    }
+
+    /**
+     * Set the available view modes, replacing any existing ones
+     *
+     * @param ViewMode ...$viewModes
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException If $viewModes is empty
+     */
+    public function setViewModes(ViewMode ...$viewModes): static
+    {
+        if (empty($viewModes)) {
+            throw new InvalidArgumentException('At least one view mode is required.');
+        }
+
+        $this->viewModes = [];
+        foreach ($viewModes as $viewMode) {
+            $this->viewModes[$viewMode->getName()] = $viewMode;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a view mode, replacing an existing one if the name is already used
+     *
+     * @param ViewMode $viewMode
+     *
+     * @return $this
+     */
+    public function addViewMode(ViewMode $viewMode): static
+    {
+        $this->viewModes[$viewMode->getName()] = $viewMode;
+
+        return $this;
+    }
+
+    /**
+     * Remove the view mode with the given name
+     *
+     * @param string $name
+     *
+     * @return $this
+     *
+     * @throws LogicException When attempting to remove the last view mode
+     */
+    public function removeViewMode(string $name): static
+    {
+        if (isset($this->viewModes[$name]) && count($this->viewModes) === 1) {
+            throw new LogicException('Cannot remove the last view mode.');
+        }
+
+        unset($this->viewModes[$name]);
+
+        return $this;
+    }
+
+    /**
+     * Get the default view mode
+     *
+     * Falls back to the first view mode if no default view mode was set and {@see self::DEFAULT_VIEW_MODE} was removed
+     *
+     * @return ViewMode
+     */
+    public function getDefaultViewMode(): ViewMode
+    {
+        if ($this->defaultViewMode !== null) {
+            return $this->viewModes[$this->defaultViewMode];
+        }
+
+        return $this->viewModes[static::DEFAULT_VIEW_MODE] ?? $this->viewModes[array_key_first($this->viewModes)];
+    }
+
+    /**
+     * Set the default view mode by its name
+     *
+     * @param string $defaultViewMode
+     *
+     * @return $this
+     */
+    public function setDefaultViewMode(string $defaultViewMode): static
+    {
+        $this->defaultViewMode = $defaultViewMode;
+
+        return $this;
+    }
+
+    /**
+     * Get the view mode URL parameter
+     *
+     * @return string
+     */
+    public function getViewModeParam(): string
+    {
+        return $this->viewModeParam;
+    }
+
+    /**
+     * Set the view mode URL parameter
+     *
+     * @param string $viewModeParam
+     *
+     * @return $this
+     */
+    public function setViewModeParam(string $viewModeParam): static
+    {
+        $this->viewModeParam = $viewModeParam;
+
+        return $this;
+    }
+
+    /**
+     * Get the active view mode
+     *
+     * @return ViewMode
+     */
+    public function getViewMode(): ViewMode
+    {
+        $viewModeName = $this->getPopulatedValue($this->getViewModeParam(), $this->getDefaultViewMode()->getName());
+
+        // View mode stays null if explicitly populated with null.
+        if ($viewModeName !== null && array_key_exists($viewModeName, $this->viewModes)) {
+            return $this->viewModes[$viewModeName];
+        }
+
+        return $this->getDefaultViewMode();
+    }
+
+    /**
+     * Set the active view mode by name
+     *
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function setViewMode(string $name): static
+    {
+        $this->populate([$this->getViewModeParam() => $name]);
+
+        return $this;
+    }
+
+    /**
+     * Set callback to protect ids with
+     *
+     * @param callable(string): string $protector
+     *
+     * @return $this
+     */
+    public function setIdProtector(callable $protector): static
+    {
+        $this->protector = $protector;
+
+        return $this;
+    }
+
+    private function protectId(string $id): string
+    {
+        if (is_callable($this->protector)) {
+            return call_user_func($this->protector, $id);
+        }
+
+        return $id;
+    }
+
+    protected function assemble(): void
+    {
+        $viewModeParam = $this->getViewModeParam();
+
+        $this->addElement($this->createUidElement());
+        $this->addElement(new HiddenElement($viewModeParam));
+
+        foreach ($this->viewModes as $name => $viewMode) {
+            $protectedId = $this->protectId('view-mode-switcher-' . $name);
+            $input = new InputElement($viewModeParam, [
+                'class' => 'autosubmit',
+                'id' => $protectedId,
+                'name' => $viewModeParam,
+                'type' => 'radio',
+                'value' => $name
+            ]);
+            $input->getAttributes()->registerAttributeCallback('checked', function () use ($name) {
+                return $name === $this->getViewMode()->getName();
+            });
+
+            $label = new HtmlElement(
+                'label',
+                Attributes::create([
+                    'for' => $protectedId
+                ]),
+                $viewMode->getIcon()
+            );
+            $label->getAttributes()->registerAttributeCallback('title', function () use ($name, $viewMode) {
+                return $viewMode->getTitle($name === $this->getViewMode()->getName());
+            });
+
+            $this->addHtml($input, $label);
+        }
+    }
+}

--- a/src/Control/ViewModeSwitcher/ViewMode.php
+++ b/src/Control/ViewModeSwitcher/ViewMode.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace ipl\Web\Control\ViewModeSwitcher;
+
+use ipl\Web\Control\LimitControl;
+use ipl\Web\Control\ViewModeSwitcher;
+use ipl\Web\Widget\IcingaIcon;
+
+/**
+ * A view mode for the {@see ViewModeSwitcher}
+ */
+class ViewMode
+{
+    /**
+     * Create a new view mode
+     *
+     * @param string $name The identifier of the view mode, which is used as value of the view mode url param
+     * @param string $icon The name of the {@see IcingaIcon} of the view mode
+     * @param string $activeTitle The title to show while the view mode is active
+     * @param string $inactiveTitle The title to show while the view mode is inactive
+     * @param int $pageSize The default page size for this view mode
+     */
+    public function __construct(
+        protected string $name,
+        protected string $icon,
+        protected string $activeTitle,
+        protected string $inactiveTitle,
+        protected int $pageSize = LimitControl::DEFAULT_LIMIT
+    ) {
+    }
+
+    /**
+     * Get the name of this view mode
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get the {@see IcingaIcon} to show for this view mode
+     *
+     * @return IcingaIcon
+     */
+    public function getIcon(): IcingaIcon
+    {
+        return new IcingaIcon($this->icon);
+    }
+
+    /**
+     * Get the title for this view mode
+     *
+     * @param bool $active Whether this mode is currently active
+     *
+     * @return string
+     */
+    public function getTitle(bool $active): string
+    {
+        return $active ? $this->activeTitle : $this->inactiveTitle;
+    }
+
+    /**
+     * Get the default page size for this view mode
+     *
+     * @return int
+     */
+    public function getPageSize(): int
+    {
+        return $this->pageSize;
+    }
+}

--- a/tests/Common/ControlsTest.php
+++ b/tests/Common/ControlsTest.php
@@ -1,0 +1,433 @@
+<?php
+
+namespace ipl\Tests\Web\Common;
+
+use Icinga\Application\EmbeddedWeb;
+use Icinga\Application\Icinga;
+use Icinga\Web\Request;
+use ipl\Html\Form;
+use ipl\I18n\NoopTranslator;
+use ipl\I18n\StaticTranslator;
+use ipl\Stdlib\Events;
+use ipl\Tests\Web\TestCase;
+use ipl\Web\Common\Controls;
+use ipl\Web\Control\ViewModeSwitcher;
+use ipl\Web\Control\ViewModeSwitcher\ViewMode;
+use ipl\Web\Url;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Stand-in for {@see \ipl\Web\Compat\CompatController}
+ *
+ * Provides what the {@see Controls} trait requires of its user, with public seams onto its protected orchestration
+ */
+class ControlsSubject
+{
+    use Events;
+    use Controls {
+        trackControl as public;
+        getTrackedControl as public;
+        handleControls as public;
+    }
+
+    /** @var ?Url The url the controls redirected to */
+    public $redirectedTo = null;
+
+    /**
+     * Record the redirect, the real implementation ends the request here
+     *
+     * @param Url $url
+     *
+     * @return void
+     */
+    public function redirectNow($url)
+    {
+        $this->redirectedTo = $url;
+    }
+}
+
+// phpcs:ignore PSR1.Classes.ClassDeclaration.MultipleClasses
+class ControlsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        StaticTranslator::$instance = new NoopTranslator();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['QUERY_STRING']);
+    }
+
+    public function testCreateViewModeSwitcherTracksTheSwitcher(): void
+    {
+        $controls = new ControlsSubject();
+        $switcher = $controls->createViewModeSwitcher();
+
+        $this->assertSame(
+            $switcher,
+            $controls->getTrackedControl(ViewModeSwitcher::class),
+            'The created switcher should be tracked'
+        );
+    }
+
+    public function testGetTrackedControlReturnsNullIfNoControlOfTheGivenTypeIsTracked(): void
+    {
+        $this->assertNull((new ControlsSubject())->getTrackedControl(ViewModeSwitcher::class));
+    }
+
+    public function testHandleControlsHandlesEveryTrackedControl(): void
+    {
+        $first = $this->createMock(Form::class);
+        $first->expects($this->once())->method('handleRequest');
+
+        $second = $this->createMock(Form::class);
+        $second->expects($this->once())->method('handleRequest');
+
+        $controls = new ControlsSubject();
+        $controls->trackControl($first);
+        $controls->trackControl($second);
+
+        $controls->handleControls($this->request('GET'));
+    }
+
+    public function testTheSwitcherIsPopulatedWithTheViewModeFromTheUrl(): void
+    {
+        $controls = new ControlsSubject();
+        $switcher = $controls->createViewModeSwitcher();
+
+        $controls->handleControls($this->request('GET', ['view' => 'minimal', 'foo' => 'bar']));
+
+        $this->assertSame(
+            'minimal',
+            $switcher->getViewMode()->getName(),
+            'The view mode should be populated from the url'
+        );
+    }
+
+    public function testTheDefaultViewModeAppliesIfTheUrlHasNoViewModeParam(): void
+    {
+        $controls = new ControlsSubject();
+        $switcher = $controls->createViewModeSwitcher();
+
+        $controls->handleControls($this->request('GET'));
+
+        $this->assertSame(
+            ViewModeSwitcher::DEFAULT_VIEW_MODE,
+            $switcher->getViewMode()->getName(),
+            'Without a param the default view mode should apply'
+        );
+    }
+
+    public function testAnUnknownViewModeInTheUrlFallsBackToTheDefault(): void
+    {
+        $controls = new ControlsSubject();
+        $switcher = $controls->createViewModeSwitcher();
+
+        $controls->handleControls($this->request('GET', ['view' => 'no-such-mode']));
+
+        $this->assertSame(
+            ViewModeSwitcher::DEFAULT_VIEW_MODE,
+            $switcher->getViewMode()->getName(),
+            'An unknown view mode should not be adopted'
+        );
+    }
+
+    public function testTheDefaultViewModeIsResolvedLazily(): void
+    {
+        $controls = new ControlsSubject();
+        $switcher = $controls->createViewModeSwitcher();
+
+        $controls->handleControls($this->request('GET'));
+        $switcher->setDefaultViewMode('detailed');
+
+        $this->assertSame(
+            'detailed',
+            $switcher->getViewMode()->getName(),
+            'A default set after the request has been handled should be honored, as it is read lazily'
+        );
+    }
+
+    public function testAViewModeInTheUrlWinsOverTheDefaultViewMode(): void
+    {
+        $controls = new ControlsSubject();
+        $switcher = $controls->createViewModeSwitcher();
+
+        $controls->handleControls($this->request('GET', ['view' => 'minimal']));
+        $switcher->setDefaultViewMode('detailed');
+
+        $this->assertSame(
+            'minimal',
+            $switcher->getViewMode()->getName(),
+            'A present param should win over the default'
+        );
+    }
+
+    public function testACustomViewModeParamIsRespected(): void
+    {
+        $controls = new ControlsSubject();
+        $switcher = $controls->createViewModeSwitcher();
+        $switcher->setViewModeParam('layout');
+
+        $controls->handleControls($this->request('GET', ['layout' => 'detailed', 'view' => 'minimal']));
+
+        $this->assertSame(
+            'detailed',
+            $switcher->getViewMode()->getName(),
+            'The view mode should be read from the custom param'
+        );
+    }
+
+    public function testViewModeSetIsEmittedWithThePopulatedSwitcher(): void
+    {
+        $controls = new ControlsSubject();
+        $switcher = $controls->createViewModeSwitcher();
+
+        $viewModeName = null;
+        $emittedFor = null;
+        $controls->on(
+            ControlsSubject::ON_VIEW_MODE_SET,
+            function (ViewModeSwitcher $switcher) use (&$viewModeName, &$emittedFor): void {
+                $viewModeName = $switcher->getViewMode()->getName();
+                $emittedFor = $switcher;
+            }
+        );
+
+        $controls->handleControls($this->request('GET', ['view' => 'detailed']));
+
+        $this->assertSame($switcher, $emittedFor, 'The event should be emitted with the created switcher');
+        $this->assertSame(
+            'detailed',
+            $viewModeName,
+            'The switcher should already be populated when the event is emitted'
+        );
+    }
+
+    public function testChangingTheViewModeRedirectsWithTheNewViewMode(): void
+    {
+        $this->expectRedirect(['view' => 'common']);
+
+        $controls = new ControlsSubject();
+        $controls->createViewModeSwitcher();
+
+        $controls->handleControls($this->submitViewMode('minimal', ['view' => 'common']));
+
+        $this->assertNotNull($controls->redirectedTo, 'A changed view mode should redirect');
+        $this->assertSame(
+            'minimal',
+            $controls->redirectedTo->getParam('view'),
+            'The new view mode should be redirected to'
+        );
+    }
+
+    public function testKeepingTheViewModeDoesNotRedirect(): void
+    {
+        $controls = new ControlsSubject();
+        $controls->createViewModeSwitcher();
+
+        $controls->handleControls($this->submitViewMode('minimal', ['view' => 'minimal']));
+
+        $this->assertNull($controls->redirectedTo, 'Submitting the active view mode should not redirect');
+    }
+
+    public function testViewModeChangeIsEmittedWithThePreviousViewMode(): void
+    {
+        $this->expectRedirect(['view' => 'minimal']);
+
+        $controls = new ControlsSubject();
+        $controls->createViewModeSwitcher();
+
+        $previousViewModeName = null;
+        $newViewModeName = null;
+        $controls->on(
+            ControlsSubject::ON_VIEW_MODE_CHANGE,
+            function (
+                ViewModeSwitcher $switcher,
+                ViewMode $previous
+            ) use (
+                &$previousViewModeName,
+                &$newViewModeName
+            ): void {
+                $previousViewModeName = $previous->getName();
+                $newViewModeName = $switcher->getViewMode()->getName();
+            }
+        );
+
+        $controls->handleControls($this->submitViewMode('detailed', ['view' => 'minimal']));
+
+        $this->assertSame('minimal', $previousViewModeName, 'The view mode of the url should be the previous one');
+        $this->assertSame('detailed', $newViewModeName, 'The switcher should already provide the new view mode');
+    }
+
+    public function testTheDefaultViewModeIsUsedAsThePreviousViewMode(): void
+    {
+        $this->expectRedirect();
+
+        $controls = new ControlsSubject();
+        $switcher = $controls->createViewModeSwitcher();
+        $switcher->setDefaultViewMode('detailed');
+
+        $previousViewModeName = null;
+        $controls->on(
+            ControlsSubject::ON_VIEW_MODE_CHANGE,
+            function (ViewModeSwitcher $switcher, ViewMode $previous) use (&$previousViewModeName): void {
+                $previousViewModeName = $previous->getName();
+            }
+        );
+
+        $controls->handleControls($this->submitViewMode('minimal'));
+
+        $this->assertSame(
+            'detailed',
+            $previousViewModeName,
+            'The default view mode should be the previous one, if the url has no view mode param'
+        );
+    }
+
+    public function testSubmittingTheDefaultViewModeWithoutAViewModeParamDoesNotRedirect(): void
+    {
+        $controls = new ControlsSubject();
+        $controls->createViewModeSwitcher();
+
+        $controls->handleControls($this->submitViewMode(ViewModeSwitcher::DEFAULT_VIEW_MODE));
+
+        $this->assertNull(
+            $controls->redirectedTo,
+            'Submitting the view mode that is already shown should not redirect, even if the url does not name it'
+        );
+    }
+
+    public function testViewModeChangeIsNotEmittedIfTheViewModeStaysTheSame(): void
+    {
+        $controls = new ControlsSubject();
+        $controls->createViewModeSwitcher();
+
+        $emitted = false;
+        $controls->on(ControlsSubject::ON_VIEW_MODE_CHANGE, function () use (&$emitted): void {
+            $emitted = true;
+        });
+
+        $controls->handleControls($this->submitViewMode('minimal', ['view' => 'minimal']));
+
+        $this->assertFalse($emitted, 'An unchanged view mode should not emit the event');
+    }
+
+    public function testViewModeChangeIsEmittedBeforeTheRedirect(): void
+    {
+        $this->expectRedirect(['view' => 'common']);
+
+        $controls = new ControlsSubject();
+        $controls->createViewModeSwitcher();
+
+        // Assertions must not be made in the listener. Form::handleRequest() catches everything an
+        // ON_SUBMIT listener throws, which would let a failing assertion pass unnoticed.
+        $redirectedWhenEmitted = null;
+        $controls->on(
+            ControlsSubject::ON_VIEW_MODE_CHANGE,
+            function () use ($controls, &$redirectedWhenEmitted): void {
+                $redirectedWhenEmitted = $controls->redirectedTo !== null;
+            }
+        );
+
+        $controls->handleControls($this->submitViewMode('minimal', ['view' => 'common']));
+
+        $this->assertNotNull($redirectedWhenEmitted, 'The view mode change should have been emitted');
+        $this->assertFalse(
+            $redirectedWhenEmitted,
+            'Listeners registered after the factory must run before the redirect'
+        );
+    }
+
+    public function testListenersMayAdjustTheRedirectUrl(): void
+    {
+        $this->expectRedirect(['view' => 'common', 'foo' => 'bar']);
+
+        $controls = new ControlsSubject();
+        $controls->createViewModeSwitcher();
+
+        $controls->on(
+            ControlsSubject::ON_VIEW_MODE_CHANGE,
+            function (ViewModeSwitcher $switcher, ViewMode $previous, Url $redirectUrl): void {
+                $redirectUrl->setParam('page', '2')
+                    ->remove('foo');
+            }
+        );
+
+        $controls->handleControls($this->submitViewMode('minimal', ['view' => 'common', 'foo' => 'bar']));
+
+        $this->assertNotNull($controls->redirectedTo, 'A changed view mode should redirect');
+        $this->assertSame('2', $controls->redirectedTo->getParam('page'), 'Listeners should be able to add params');
+        $this->assertFalse($controls->redirectedTo->hasParam('foo'), 'Listeners should be able to remove params');
+        $this->assertSame(
+            'minimal',
+            $controls->redirectedTo->getParam('view'),
+            'The new view mode should still be applied'
+        );
+    }
+
+    /**
+     * Get a request submitting the given view mode
+     *
+     * Tests that expect a redirect have to call {@see self::expectRedirect()} first
+     *
+     * @param string $viewMode
+     * @param array<string, mixed> $queryParams
+     *
+     * @return ServerRequestInterface
+     */
+    private function submitViewMode(string $viewMode, array $queryParams = []): ServerRequestInterface
+    {
+        return $this->request('POST', $queryParams, ['uid' => 'view-mode-switcher', 'view' => $viewMode]);
+    }
+
+    /**
+     * Get a request mock
+     *
+     * @param string $method
+     * @param array<string, mixed> $queryParams
+     * @param array<string, mixed> $body
+     *
+     * @return ServerRequestInterface
+     */
+    private function request(string $method, array $queryParams = [], array $body = []): ServerRequestInterface
+    {
+        return $this->createConfiguredMock(ServerRequestInterface::class, [
+            'getMethod' => $method,
+            'getUploadedFiles' => [],
+            'getQueryParams' => $queryParams,
+            'getParsedBody' => $body,
+            'getUri' => $this->createConfiguredMock(UriInterface::class, [
+                'getQuery' => http_build_query($queryParams)
+            ])
+        ]);
+    }
+
+    /**
+     * Set up just enough of Icinga Web to let the redirect's {@see Url::fromRequest()} work
+     *
+     * Skips the test if Icinga Web is not available, as {@see Url} cannot even be loaded without it
+     *
+     * @param array<string, mixed> $queryParams The query params the request is expected to be redirected from
+     *
+     * @return void
+     */
+    private function expectRedirect(array $queryParams = []): void
+    {
+        if (! class_exists(Icinga::class)) {
+            $this->markTestSkipped('Redirects require Icinga Web');
+        }
+
+        $_SERVER['QUERY_STRING'] = http_build_query($queryParams);
+
+        Icinga::setApp(
+            $this->createConfiguredMock(EmbeddedWeb::class, [
+                'getRequest' => $this->createConfiguredMock(Request::class, [
+                    'getPathInfo' => '/test',
+                    'getBaseUrl' => '/'
+                ])
+            ]),
+            true
+        );
+    }
+}


### PR DESCRIPTION
resolve #340 

A `ViewModeSwitcher` class similar to the one in icingadb-web is added. It was reworked so that adding and removing view modes can be done without declaring a subclass.
To allow this the `ViewMode` class is added, which contains name, icon, titles for active/inactive state and the default page size.

The `Controls` trait is added with a `createViewModeSwitcher()` function.
It registers a listener to `ViewModeSwitcher::ON_REQUEST`, which populates the `ViewModeSwitcher` with the view mode from the url and emits `ON_VIEW_MODE_SET`.
If the view mode is changed, a `ViewModeSwitcher::ON_SUBMIT` listener emits `ON_VIEW_MODE_CHANGE` with the `ViewModeSwitcher`, its previous view mode and a `$redirectUrl` that listeners may modify.

The `handleControls()` function suggested in #340 is implemented, which calls `handleRequest()` for all controls passed to `trackControl()` , in case of the `ViewModeSwitcher` this is done by the factory method.

The `CompatController` registers listeners on the trait's events in the `createLimitControl()` and `createPaginationControl()` factories, to adjust the default limit, page size to teh current view mode, and correct the current page when the view mode is changed.

`SearchControls::createSearchBar()` is adjusted to shift the view mode param before building its filter, because the `Controls` trait does not have access to the `UrlParams`.