### PR TITLE
Add `CompatForm::logAndShowError()`

### DIFF
--- a/src/Compat/CompatForm.php
+++ b/src/Compat/CompatForm.php
@@ -197,21 +197,20 @@ class CompatForm extends Form
     /**
      * Log an error and surface it as a form message
      *
-     * When $messageTemplate needs additional formatting before the error message is inserted,
-     * pre-format it with `sprintf()` and escape the error message placeholder as `%%s`:
+     * $template may contain a `{error}` placeholder, which is replaced with the error
+     * message. Any additional $args are forwarded to {@see Form::addMessage()} for
+     * further `sprintf()`-style formatting of $template:
      *
-     *     $this->logAndShowError(
-     *         $e,
-     *         sprintf($this->translate('Method "%s" failed: %%s'), $name)
-     *     );
+     *     $this->logAndShowError($e, $this->translate('Method "%s" failed: {error}'), $name);
      *
      * @param Throwable|Stringable|string $error Exception or error message to log and display
-     * @param string $messageTemplate Message to show in the form. %s is replaced with the
+     * @param string $template Message to show in the form. {error} is replaced with the
      *   error message.
+     * @param mixed ...$args Additional arguments for $template
      *
      * @return void
      */
-    protected function logAndShowError(Throwable|Stringable|string $error, string $messageTemplate): void
+    protected function logAndShowError(Throwable|Stringable|string $error, string $template, mixed ...$args): void
     {
         if ($error instanceof Throwable) {
             Logger::error("%s\n%s", $error->getMessage(), IcingaException::getConfidentialTraceAsString($error));
@@ -221,7 +220,7 @@ class CompatForm extends Form
             $errorMessage = $error;
         }
 
-        $this->addMessage($messageTemplate, $errorMessage);
+        $this->addMessage(str_replace('{error}', $errorMessage, $template), ...$args);
         $this->onError();
     }
 }

--- a/src/Compat/CompatForm.php
+++ b/src/Compat/CompatForm.php
@@ -203,14 +203,14 @@ class CompatForm extends Form
      *
      *     $this->logAndShowError($e, $this->translate('Method "%s" failed: {error}'), $name);
      *
-     * @param Throwable|Stringable|string $error Exception or error message to log and display
+     * @param Throwable|string $error Exception or error message to log and display
      * @param string $template Message to show in the form. {error} is replaced with the
      *   error message.
      * @param mixed ...$args Additional arguments for $template
      *
      * @return void
      */
-    protected function logAndShowError(Throwable|Stringable|string $error, string $template, mixed ...$args): void
+    protected function logAndShowError(Throwable|string $error, string $template, mixed ...$args): void
     {
         if ($error instanceof Throwable) {
             Logger::error("%s\n%s", $error->getMessage(), IcingaException::getConfidentialTraceAsString($error));

--- a/src/Compat/CompatForm.php
+++ b/src/Compat/CompatForm.php
@@ -3,6 +3,8 @@
 namespace ipl\Web\Compat;
 
 use Icinga\Application\Icinga;
+use Icinga\Application\Logger;
+use Icinga\Exception\IcingaException;
 use InvalidArgumentException;
 use ipl\Html\Contract\FormElement;
 use ipl\Html\Contract\FormSubmitElement;
@@ -16,6 +18,8 @@ use ipl\I18n\Translation;
 use ipl\Web\Compat\FormDecorator\PrimaryButtonDecorator;
 use ipl\Web\FormDecorator\IcingaFormDecorator;
 use ipl\Web\Compat\FormDecorator\LabelDecorator;
+use Stringable;
+use Throwable;
 
 class CompatForm extends Form
 {
@@ -188,5 +192,36 @@ class CompatForm extends Form
             'Cannot duplicate submit button of type "%s"',
             get_class($originalSubmitButton)
         ));
+    }
+
+    /**
+     * Log an error and surface it as a form message
+     *
+     * When $messageTemplate needs additional formatting before the error message is inserted,
+     * pre-format it with `sprintf()` and escape the error message placeholder as `%%s`:
+     *
+     *     $this->logAndShowError(
+     *         $e,
+     *         sprintf($this->translate('Method "%s" failed: %%s'), $name)
+     *     );
+     *
+     * @param Throwable|Stringable|string $error Exception or error message to log and display
+     * @param string $messageTemplate Message to show in the form. %s is replaced with the
+     *   error message.
+     *
+     * @return void
+     */
+    protected function logAndShowError(Throwable|Stringable|string $error, string $messageTemplate): void
+    {
+        if ($error instanceof Throwable) {
+            Logger::error("%s\n%s", $error->getMessage(), IcingaException::getConfidentialTraceAsString($error));
+            $errorMessage = $error->getMessage();
+        } else {
+            Logger::error($error);
+            $errorMessage = $error;
+        }
+
+        $this->addMessage($messageTemplate, $errorMessage);
+        $this->onError();
     }
 }


### PR DESCRIPTION
Subclasses that catch an exception or otherwise fail during processing previously had to repeat the same three steps by hand:

1. log the error
2. add it as a form message
3. call `onError()` to mark the form as failed

`logAndShowError()` bundles this into one call.

Exceptions are logged with their confidential stack trace (argument values redacted, types only) via `IcingaException::getConfidentialTraceAsString()`, so call sites don't need to worry about leaking sensitive data into the log. Plain strings and `Stringable` messages are logged as-is.