### PR TITLE
Add tests for `CompatForm::logAndShowError()`

### DIFF
--- a/src/Compat/CompatForm.php
+++ b/src/Compat/CompatForm.php
@@ -3,6 +3,8 @@
 namespace ipl\Web\Compat;
 
 use Icinga\Application\Icinga;
+use Icinga\Application\Logger;
+use Icinga\Exception\IcingaException;
 use InvalidArgumentException;
 use ipl\Html\Contract\FormElement;
 use ipl\Html\Contract\FormSubmitElement;
@@ -16,6 +18,8 @@ use ipl\I18n\Translation;
 use ipl\Web\Compat\FormDecorator\PrimaryButtonDecorator;
 use ipl\Web\FormDecorator\IcingaFormDecorator;
 use ipl\Web\Compat\FormDecorator\LabelDecorator;
+use Stringable;
+use Throwable;
 
 class CompatForm extends Form
 {
@@ -188,5 +192,36 @@ class CompatForm extends Form
             'Cannot duplicate submit button of type "%s"',
             get_class($originalSubmitButton)
         ));
+    }
+
+    /**
+     * Log an error and surface it as a form message
+     *
+     * When $messageTemplate needs additional formatting before the error message is inserted,
+     * pre-format it with `sprintf()` and escape the error message placeholder as `%%s`:
+     *
+     *     $this->logAndShowError(
+     *         $e,
+     *         sprintf($this->translate('Method "%s" failed: %%s'), $name)
+     *     );
+     *
+     * @param Throwable|Stringable|string $error Exception or error message to log and display
+     * @param string $messageTemplate Message to show in the form. %s is replaced with the
+     *   error message.
+     *
+     * @return void
+     */
+    protected function logAndShowError(Throwable|Stringable|string $error, string $messageTemplate): void
+    {
+        if ($error instanceof Throwable) {
+            Logger::error("%s\n%s", $error->getMessage(), IcingaException::getConfidentialTraceAsString($error));
+            $errorMessage = $error->getMessage();
+        } else {
+            Logger::error($error);
+            $errorMessage = $error;
+        }
+
+        $this->addMessage($messageTemplate, $errorMessage);
+        $this->onError();
     }
 }

--- a/tests/Compat/CompatFormTest.php
+++ b/tests/Compat/CompatFormTest.php
@@ -2,11 +2,14 @@
 
 namespace ipl\Tests\Web\Compat;
 
+use Exception;
 use ipl\Html\FormElement\SubmitElement;
 use ipl\Html\Test\TestCase;
 use ipl\I18n\NoopTranslator;
 use ipl\I18n\StaticTranslator;
 use ipl\Web\Compat\CompatForm;
+use Stringable;
+use Throwable;
 
 class CompatFormTest extends TestCase
 {
@@ -384,5 +387,85 @@ HTML;
 HTML;
 
         $this->assertHtml($expected, $form);
+    }
+
+    public function testLogAndShowErrorLogsAndDisplaysThrowableMessage(): void
+    {
+        $form = $this->createFormExposingLogAndShowError();
+
+        $form->exposeLogAndShowError(new Exception('Something went wrong'), 'Could not save: %s');
+
+        $this->assertSame(['Could not save: Something went wrong'], $form->getMessages());
+    }
+
+    public function testLogAndShowErrorLogsAndDisplaysStringMessage(): void
+    {
+        $form = $this->createFormExposingLogAndShowError();
+
+        $form->exposeLogAndShowError('Disk full', 'Could not save: %s');
+
+        $this->assertSame(['Could not save: Disk full'], $form->getMessages());
+    }
+
+    public function testLogAndShowErrorAcceptsStringableMessage(): void
+    {
+        $form = $this->createFormExposingLogAndShowError();
+
+        $error = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'Disk full';
+            }
+        };
+
+        $form->exposeLogAndShowError($error, 'Could not save: %s');
+
+        $this->assertSame(['Could not save: Disk full'], $form->getMessages());
+    }
+
+    public function testLogAndShowErrorSupportsPreFormattedMessageTemplates(): void
+    {
+        $form = $this->createFormExposingLogAndShowError();
+
+        $messageTemplate = sprintf('Method "%s" failed: %%s', 'someMethod');
+        $form->exposeLogAndShowError(new Exception('Disk full'), $messageTemplate);
+
+        $this->assertSame(['Method "someMethod" failed: Disk full'], $form->getMessages());
+    }
+
+    public function testLogAndShowErrorIgnoresErrorMessageWhenTemplateHasNoPlaceholder(): void
+    {
+        $form = $this->createFormExposingLogAndShowError();
+
+        $form->exposeLogAndShowError(new Exception('Something went wrong'), 'Could not save the record');
+
+        $this->assertSame(['Could not save the record'], $form->getMessages());
+    }
+
+    public function testLogAndShowErrorMarksTheFormAsFailed(): void
+    {
+        $form = $this->createFormExposingLogAndShowError();
+
+        $form->exposeLogAndShowError(new Exception('Something went wrong'), 'Could not save: %s');
+
+        $expected = <<<'HTML'
+    <form class="icinga-form icinga-controls" method="POST">
+        <ul class="errors">
+            <li>Could not save: Something went wrong</li>
+        </ul>
+    </form>
+HTML;
+
+        $this->assertHtml($expected, $form);
+    }
+
+    protected function createFormExposingLogAndShowError(): CompatForm
+    {
+        return new class extends CompatForm {
+            public function exposeLogAndShowError(Throwable|Stringable|string $error, string $messageTemplate): void
+            {
+                $this->logAndShowError($error, $messageTemplate);
+            }
+        };
     }
 }


### PR DESCRIPTION
These are the tests for `CompatForm::logAndShowError()`, split off into their own branch because they can't run yet: our test bootstrap has no autoloadable `Icinga\Application\Logger`, which the method calls unconditionally, so running them currently fails with `Class "Icinga\Application\Logger" not found`. This is opened as a draft so the tests aren't lost in the meantime. Once the test structure is updated to provide (or stub) that class, this can be rebased and merged.

ref #393 