### PR TITLE
Callout: Normalize text content spacing

### DIFF
--- a/asset/css/callout.less
+++ b/asset/css/callout.less
@@ -16,13 +16,26 @@
     margin: 0;
   }
 
-  .callout-title {
-    margin-bottom: .5em;
-  }
-
   .callout-text {
     display: flex;
     flex-direction: column;
+
+    & > * {
+      margin: 0;
+    }
+
+    & > ul,
+    & > ol {
+      padding-left: 1em;
+    }
+
+    & > p {
+      padding: 0;
+    }
+
+    .callout-title {
+      margin-bottom: .5em;
+    }
   }
 }
 

--- a/asset/css/callout.less
+++ b/asset/css/callout.less
@@ -12,31 +12,32 @@
     margin-right: 0;
   }
 
-  p {
-    margin: 0;
-  }
-
   .callout-text {
     display: flex;
     flex-direction: column;
-
-    & > * {
-      margin: 0;
-    }
-
-    & > ul,
-    & > ol {
-      padding-left: 1em;
-    }
-
-    & > p {
-      padding: 0;
-    }
 
     .callout-title {
       margin-bottom: .5em;
     }
   }
+}
+
+// Flex item margins do not collapse, so remove browser spacing from callout content.
+// Keep the reset at zero specificity so caller styles can override it.
+:where(.callout .callout-text > *) {
+  margin: 0;
+}
+
+// Icinga Web declares paragraph margins later, so add type specificity without
+// changing the match; caller classes remain stronger than this reset.
+:where(.callout .callout-text) > p:not(html) {
+  margin: 0;
+}
+
+// Keep list markers with compact indentation instead of the browser default.
+:where(.callout .callout-text > ul),
+:where(.callout .callout-text > ol) {
+  padding-left: 1em;
 }
 
 // Style


### PR DESCRIPTION
Move `.callout-title` inside `.callout-text` to scope it correctly, and add rules to strip default margin from direct children of `.callout-text`.

This improves the display of lists and paragraphs.

**before**
<img width="765" height="836" alt="Screenshot From 2026-07-17 09-18-48" src="https://github.com/user-attachments/assets/f0300fb1-8a19-47d7-bd47-971cf24151cd" />

**after**
<img width="765" height="680" alt="Screenshot From 2026-07-17 09-16-00" src="https://github.com/user-attachments/assets/bb5e2283-00fb-4b62-bb00-a85f1da0427f" />
