### PR TITLE
Override `onError()` in `CompatForm` for prettier form errors

### DIFF
--- a/asset/css/compat.less
+++ b/asset/css/compat.less
@@ -148,6 +148,11 @@ form.icinga-form .suggestion-element-group {
   }
 }
 
+// Form error callout styles
+form > .error-callouts > .callout-type-error:not(:last-child) {
+  margin-bottom: .5em;
+}
+
 // Display form element styles
 form.icinga-form .control-group > .display-form-element {
   flex: 1 1 auto;

--- a/src/Compat/CompatForm.php
+++ b/src/Compat/CompatForm.php
@@ -6,6 +6,7 @@ use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
 use Icinga\Exception\IcingaException;
 use InvalidArgumentException;
+use ipl\Html\Attributes;
 use ipl\Html\Contract\FormElement;
 use ipl\Html\Contract\FormSubmitElement;
 use ipl\Html\Contract\HtmlElementInterface;
@@ -13,11 +14,14 @@ use ipl\Html\Form;
 use ipl\Html\FormElement\SubmitButtonElement;
 use ipl\Html\FormElement\SubmitElement;
 use ipl\Html\HtmlDocument;
+use ipl\Html\HtmlElement;
 use ipl\Html\HtmlString;
 use ipl\I18n\Translation;
+use ipl\Web\Common\CalloutType;
 use ipl\Web\Compat\FormDecorator\PrimaryButtonDecorator;
 use ipl\Web\FormDecorator\IcingaFormDecorator;
 use ipl\Web\Compat\FormDecorator\LabelDecorator;
+use ipl\Web\Widget\Callout;
 use Stringable;
 use Throwable;
 
@@ -222,5 +226,37 @@ class CompatForm extends Form
 
         $this->addMessage(str_replace('{error}', $errorMessage, $template), ...$args);
         $this->onError();
+    }
+
+    /**
+     * Render form error messages as callouts
+     *
+     * Overrides the default rendering, which produces a single `<ul class="errors">`
+     * list, to instead prepend a `<div class="error-callouts"></div>` containing
+     * one error callout per message.
+     *
+     * @return void
+     */
+    protected function onError()
+    {
+        $errors = new HtmlElement('div', new Attributes([
+            'class' => 'error-callouts',
+            'role' => 'list',
+        ]));
+
+        foreach ($this->getMessages() as $message) {
+            if ($message instanceof Throwable) {
+                $message = $message->getMessage();
+            }
+
+            $errors->addHtml(
+                (new Callout(CalloutType::Error, $message))
+                    ->setAttribute('role', 'listitem')
+            );
+        }
+
+        if (! $errors->isEmpty()) {
+            $this->prependHtml($errors);
+        }
     }
 }

--- a/tests/Compat/CompatFormTest.php
+++ b/tests/Compat/CompatFormTest.php
@@ -322,6 +322,111 @@ HTML;
         $this->assertHtml($expected, $form);
     }
 
+    public function testOnErrorRendersMultipleMessagesInSourceOrder(): void
+    {
+        $form = new class extends CompatForm {
+            public function triggerOnError(): void
+            {
+                $this->onError();
+            }
+        };
+        $form->addMessage('First error');
+        $form->addMessage('Second error');
+        $form->triggerOnError();
+
+        $expected = <<<'HTML'
+<form class="icinga-form icinga-controls" method="POST">
+    <div class="error-callouts" role="list">
+        <div class="callout callout-type-error" role="listitem">
+            <i class="icon fa-circle-xmark fa"></i>
+            <div class="callout-text">First error</div>
+        </div>
+        <div class="callout callout-type-error" role="listitem">
+            <i class="icon fa-circle-xmark fa"></i>
+            <div class="callout-text">Second error</div>
+        </div>
+    </div>
+</form>
+HTML;
+
+        $this->assertHtml($expected, $form);
+    }
+
+    public function testOnErrorRendersMessagesAboveElements(): void
+    {
+        $form = new class extends CompatForm {
+            protected function assemble(): void
+            {
+                $this->addElement('submit', 'submit_form', ['label' => 'Submit']);
+            }
+
+            public function triggerOnError(): void
+            {
+                $this->onError();
+            }
+        };
+        $form->addMessage('Error occurred');
+        $form->triggerOnError();
+
+        $expected = <<<'HTML'
+<form class="icinga-form icinga-controls" method="POST">
+    <div class="error-callouts" role="list">
+        <div class="callout callout-type-error" role="listitem">
+            <i class="icon fa-circle-xmark fa"></i>
+            <div class="callout-text">Error occurred</div>
+        </div>
+    </div>
+    <div class="control-group form-controls">
+        <input class="btn-primary" value="Submit" name="submit_form" type="submit">
+    </div>
+</form>
+HTML;
+
+        $this->assertHtml($expected, $form);
+    }
+
+    public function testOnErrorEscapesHtmlInMessageText(): void
+    {
+        $form = new class extends CompatForm {
+            public function triggerOnError(): void
+            {
+                $this->onError();
+            }
+        };
+        $form->addMessage('<em>italic</em>');
+        $form->triggerOnError();
+
+        $expected = <<<'HTML'
+<form class="icinga-form icinga-controls" method="POST">
+    <div class="error-callouts" role="list">
+        <div class="callout callout-type-error" role="listitem">
+            <i class="icon fa-circle-xmark fa"></i>
+            <div class="callout-text">&lt;em&gt;italic&lt;/em&gt;</div>
+        </div>
+    </div>
+</form>
+HTML;
+
+        $this->assertHtml($expected, $form);
+    }
+
+    public function testOnErrorEmitsNoWrapperWithoutMessages(): void
+    {
+        $form = new class extends CompatForm {
+            public function triggerOnError(): void
+            {
+                $this->onError();
+            }
+        };
+        $form->triggerOnError();
+
+        $expected = <<<'HTML'
+<form class="icinga-form icinga-controls" method="POST"></form>
+HTML;
+
+        $this->assertHtml($expected, $form);
+    }
+
     public function testMethodApplyDefaultElementDecorators(): void
     {
         // A fieldset, a text element, a required checkbox, and a submit button should cover


### PR DESCRIPTION
Each form error is now shown as a separate `Callout` instead of collecting all messages into a single `<ul class="errors">`. This displays the errors in a prettier way for the user.

Before
<img width="868" height="161" alt="Screenshot 2026-07-17 at 15 11 27" src="https://github.com/user-attachments/assets/8e1e1deb-13d2-472b-94cc-6f04db334ebd" />

After
<img width="868" height="161" alt="Screenshot 2026-07-17 at 15 11 40" src="https://github.com/user-attachments/assets/1d08343e-f9c4-481e-be43-ad8fb23307c6" />
