### PR TITLE
add default styling for dropdown component

### DIFF
--- a/asset/css/dropdown.less
+++ b/asset/css/dropdown.less
@@ -1,0 +1,45 @@
+.dropdown {
+  display: inline-block;
+  position: relative;
+
+  .dropdown-toggle::after {
+    content: "";
+    display: inline-block;
+    width: 0;
+    height: 0;
+    margin-left: .255em;
+    vertical-align: .255em;
+    border-top: .3em solid;
+    border-right: .3em solid transparent;
+    border-bottom: 0;
+    border-left: .3em solid transparent;
+  }
+
+  .dropdown-menu {
+    display: none;
+    min-width: 10em;
+    border: 1px solid @gray-light;
+    background: @body-bg-color;
+    margin: -.25em;
+    border-radius: .25em;
+    padding: .25em;
+    position: absolute;
+  }
+
+  &:hover > .dropdown-menu {
+    display: block;
+    box-shadow: 0 0 2em 0 rgba(0,0,0,.2);
+  }
+
+  .dropdown-item {
+    display: block;
+    padding: .5em;
+    margin: -.25em;
+
+    &.action-link:hover {
+      padding: .5em;
+      background: @tr-hover-color;
+      .rounded-corners(0)
+    }
+  }
+}


### PR DESCRIPTION
I added a default styling for the Dropdown component which was missing before.

Therefore I used the style that is represented for a Dropdown in the reporting module
https://github.com/Icinga/icingaweb2-module-reporting/blob/f8b9d03f49e86add1c5929b1aa3cea11aeb4770d/public/css/module.less#L46

Mentions #401 