### PR TITLE
Add Configurable Sortcontrols

### DIFF
--- a/src/Compat/CompatController.php
+++ b/src/Compat/CompatController.php
@@ -2,7 +2,10 @@
 
 namespace ipl\Web\Compat;
 
+use Exception;
 use GuzzleHttp\Psr7\ServerRequest;
+use Icinga\Application\Config;
+use Icinga\Application\Logger;
 use Icinga\Application\Version;
 use InvalidArgumentException;
 use Icinga\Web\Controller;
@@ -10,6 +13,7 @@ use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlDocument;
 use ipl\Html\HtmlString;
 use ipl\Html\ValidHtml;
+use ipl\Orm\Common\SortUtil;
 use ipl\Orm\Query;
 use ipl\Stdlib\Contract\Paginatable;
 use ipl\Web\Control\LimitControl;
@@ -288,8 +292,61 @@ class CompatController extends Controller
      *
      * @return SortControl
      */
+    /**
+     * Fetch additional sort columns for the current view from /etc/icingaweb2/sortcontrols.ini
+     *
+     * An entry applies if its `type` matches the current view. The first segment is always the
+     * module name, so two segments mean module and controller (icingadb/hostgroups) and three
+     * mean module, controller and action (icingadb/host/services).
+     *
+     * @return array<string, string> Sort spec to label map
+     */
+    protected function fetchConfiguredSortColumns(): array
+    {
+        try {
+            $config = Config::app('sortcontrols');
+        } catch (Exception $e) {
+            Logger::error('Cannot load sortcontrols.ini: %s', $e->getMessage());
+
+            return [];
+        }
+
+        $request = $this->getRequest();
+        $view = $request->getModuleName() . '/' . $request->getControllerName();
+        $viewKeys = [$view, $view . '/' . $request->getActionName()];
+
+        $columns = [];
+        foreach ($config as $name => $entry) {
+            $types = array_filter(array_map('trim', explode(',', (string) $entry->get('type'))));
+            if (! array_intersect($viewKeys, $types)) {
+                continue;
+            }
+
+            $sort = trim((string) $entry->get('sort'));
+            if ($sort === '') {
+                Logger::warning('Sort control "%s" in sortcontrols.ini has no sort spec, ignoring it', $name);
+
+                continue;
+            }
+
+            $columns[SortUtil::normalizeSortSpec($sort)] = (string) ($entry->get('title') ?: $sort);
+        }
+
+        return $columns;
+    }
+
     public function createSortControl(Query $query, array $columns): SortControl
     {
+        // Normalize here already, otherwise configured specs won't deduplicate against the built-in ones
+        $normalized = [];
+        foreach ($columns as $spec => $label) {
+            $normalized[SortUtil::normalizeSortSpec($spec)] = $label;
+        }
+
+        // Union, not array_merge: built-in options keep their label and their position. The first
+        // entry is what SortControl falls back to when no sort is given, so it must not shift.
+        $columns = $normalized + $this->fetchConfiguredSortColumns();
+
         $sortControl = SortControl::create($columns);
 
         $this->params->shift($sortControl->getSortParam());


### PR DESCRIPTION
To avoid having to modify the source code every time additional `SortControls` need to be added—not only in the `icingadb-web` module, but also in modules such as Kubernetes and others—I would like to propose the following change.

The information below describes how to add additional `SortControls` to different modules that make use of `ipl-web`.



; Extra sort options for list views built on ipl-web.
;
; Location:  /etc/icingaweb2/sortcontrols.ini
; Ownership: root:icingaweb2, mode 0660 (must be readable by the web server user)
;
; One section per sort option. The section name is only an identifier and must be
; unique within this file; it is never shown in the UI. Prefixing it with the view
; keeps related options together.
;
;   type   Comma separated list of views this option applies to. The first segment is
;          always the MODULE name, not the web path -- a URL like
;          https://host/icingaweb2/notifications/incidents is module "notifications",
;          controller "incidents", so the value is "notifications/incidents".
;          Two segments mean module and controller, three mean module, controller and
;          action (icingadb/host/services).
;   sort   The full sort spec, exactly as it would appear in the ?sort= URL parameter.
;          Multiple columns are allowed, separated by commas.
;   title  Label shown in the "Sort By" dropdown. Optional; defaults to the sort spec.
;          Not translatable, since it does not end up in the .po catalogs.
;
; Options appear in the dropdown in the order they are listed here, after the ones
; that ship with the module. Columns must exist on the model backing the view; a typo
; does not break the page on load, only when someone actually selects the option.
;
;
; WHICH VIEWS WORK DEPENDS ON WHICH PATCH IS INSTALLED
;
; icingadb-web patch   -- covers the Icinga DB views only (the first block below).
; ipl-web patch        -- covers every view here, plus any other ipl-web based module.
;
; Entries for a view whose module is not patched are silently ignored: no error, no
; log line, the option simply does not appear. Keep that in mind when debugging.
;
;
; ICINGA DB WEB 1.4.0
;
; Object lists
;   icingadb/hostgroups                 Model/Hostgroupsummary.php
;   icingadb/servicegroups              Model/ServicegroupSummary.php
;   icingadb/hosts                      Model/Host.php + HostState.php
;   icingadb/services                   Model/Service.php + ServiceState.php
;   icingadb/services/grid              same, but a separate action with its own set
;
; Host and service lists inside a single group
;   icingadb/hostgroup                  Model/Host.php
;   icingadb/servicegroup               Model/Service.php
;
; Service list inside a host
;   icingadb/host/services              Model/Service.php
;
; Dependency lists -- these use Model/DependencyNode.php, so their columns are
; unqualified (name, severity, state) instead of dotted. Do not copy specs from
; the other views here without adapting them.
;   icingadb/host/parents
;   icingadb/host/children
;   icingadb/service/parents
;   icingadb/service/children
;   icingadb/redundancygroup/members
;   icingadb/redundancygroup/children
;
; History and notifications -- one built-in option each, so the most to gain here
;   icingadb/history                    Model/History.php
;   icingadb/host/history               Model/History.php
;   icingadb/service/history            Model/History.php
;   icingadb/notifications              Model/NotificationHistory.php
;
; Comments and downtimes -- icingadb/downtimes already ships with ten options and
; is the best in-tree example of how dotted relation columns are written
;   icingadb/comments                   Model/Comment.php
;   icingadb/downtimes                  Model/Downtime.php
;
; Contacts
;   icingadb/contacts                   Model/User.php
;   icingadb/contactgroups              Model/Usergroup.php
;
;
; ICINGA NOTIFICATIONS WEB (ipl-web patch required)
;
; Checked against v0.3.0. Note this module uses its own contacts and contact groups,
; unrelated to icingadb/contacts. Built-in options are listed because they are few:
;
;   notifications/events                event.time desc
;   notifications/incidents             incident.severity desc + incident.started_at,
;                                       incident.started_at desc, incident.recovered_at
;   notifications/schedules             schedule.name, changed_at
;   notifications/channels              name, type, changed_at
;   notifications/sources               name, type, changed_at
;   notifications/event-rules           name, changed_at
;   notifications/contacts              full_name, changed_at
;   notifications/contact-groups        name, changed_at
;
; notifications/events offers a single option, so it is the thinnest view of the lot.
;
;
; OTHER ipl-web MODULES (ipl-web patch required)
;
; Kubernetes, Director, x509, reporting and the like are covered as well, but their
; view names are not listed here because they vary per version. Open the view, read
; the module and controller off the URL, and use that as the type.
;
; Not covered by either patch: the Icinga Web 2 core views (users, groups, roles,
; navigation, announcements, health). Those use the older SortBox widget.


;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
; Icinga DB -- host groups
;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

[hostgroups_hst_down_unhandled]
type  = "icingadb/hostgroups"
sort  = "hosts_down_unhandled desc,hosts_pending desc"
title = "Hst Down Unhandled"

[hostgroups_hst_down_handled]
type  = "icingadb/hostgroups"
sort  = "hosts_down_handled desc,hosts_pending desc"
title = "Hst Down Handled"

[hostgroups_hst_pending]
type  = "icingadb/hostgroups"
sort  = "hosts_pending desc"
title = "Hst Pending"

[hostgroups_srv_warning_unhandled]
type  = "icingadb/hostgroups"
sort  = "services_warning_unhandled desc"
title = "Srv Unhandled Warning"

[hostgroups_srv_critical_unhandled]
type  = "icingadb/hostgroups"
sort  = "services_critical_unhandled desc"
title = "Srv Unhandled Critial"

[hostgroups_srv_unknown_unhandled]
type  = "icingadb/hostgroups"
sort  = "services_unknown_unhandled desc"
title = "Srv Unhandled Unknown"

[hostgroups_srv_critical_warning_unhandled]
type  = "icingadb/hostgroups"
sort  = "services_critical_unhandled desc,services_warning_unhandled desc"
title = "Srv Unhandled Critial,Warning"

[hostgroups_srv_total]
type  = "icingadb/hostgroups"
sort  = "services_total desc"
title = "Srv Total Services"

[hostgroups_srv_ok]
type  = "icingadb/hostgroups"
sort  = "services_ok desc"
title = "Srv Ok"

[hostgroups_srv_pending]
type  = "icingadb/hostgroups"
sort  = "services_pending desc"
title = "Srv Pending"

[hostgroups_srv_warning_handled]
type  = "icingadb/hostgroups"
sort  = "services_warning_handled desc"
title = "Srv Handled Warning"

[hostgroups_srv_unknown_handled]
type  = "icingadb/hostgroups"
sort  = "services_unknown_handled desc"
title = "Srv Handled Unknown"


;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
; Icinga DB -- service groups
;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

[servicegroups_srv_warning_unhandled]
type  = "icingadb/servicegroups"
sort  = "services_warning_unhandled desc"
title = "Srv Unhandled Warning"

[servicegroups_srv_critical_unhandled]
type  = "icingadb/servicegroups"
sort  = "services_critical_unhandled desc"
title = "Srv Unhandled Critial"

[servicegroups_srv_unknown_unhandled]
type  = "icingadb/servicegroups"
sort  = "services_unknown_unhandled desc"
title = "Srv Unhandled Unknown"

[servicegroups_srv_critical_warning_unhandled]
type  = "icingadb/servicegroups"
sort  = "services_critical_unhandled desc,services_warning_unhandled desc"
title = "Srv Unhandled Critial,Warning"

[servicegroups_srv_total]
type  = "icingadb/servicegroups"
sort  = "services_total desc"
title = "Srv Total Services"

[servicegroups_srv_ok]
type  = "icingadb/servicegroups"
sort  = "services_ok desc"
title = "Srv Ok"

[servicegroups_srv_pending]
type  = "icingadb/servicegroups"
sort  = "services_pending desc"
title = "Srv Pending"

[servicegroups_srv_warning_handled]
type  = "icingadb/servicegroups"
sort  = "services_warning_handled desc"
title = "Srv Handled Warning"

[servicegroups_srv_unknown_handled]
type  = "icingadb/servicegroups"
sort  = "services_unknown_handled desc"
title = "Srv Handled Unknown"


;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
; Icinga Notifications -- examples, disabled
;
; These need the ipl-web patch; with the icingadb-web patch they are ignored.
; Checked against Notifications Web v0.3.0. To enable, remove the leading ';'
; from the section header and its three keys.
;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

; Model/Event.php: time, object_id, type, severity, message, username, mute, mute_reason
;
;[notifications_evt_severity]
;type  = "notifications/events"
;sort  = "event.severity desc,event.time desc"
;title = "Severity"
;
;[notifications_evt_type]
;type  = "notifications/events"
;sort  = "event.type,event.time desc"
;title = "Event Type"
;
;[notifications_evt_oldest]
;type  = "notifications/events"
;sort  = "event.time"
;title = "Received On (oldest first)"

; Model/Incident.php: object_id, started_at, recovered_at, severity
;
;[notifications_inc_open_longest]
;type  = "notifications/incidents"
;sort  = "incident.started_at"
;title = "Open Longest"
;
;[notifications_inc_recovered_recent]
;type  = "notifications/incidents"
;sort  = "incident.recovered_at desc"
;title = "Recently Recovered"

; Channels, sources and event rules all sort on plain name / type / changed_at
;
;[notifications_chn_recently_changed]
;type  = "notifications/channels,notifications/sources,notifications/event-rules"
;sort  = "changed_at desc"
;title = "Recently Changed"


;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
; Icinga for Kubernetes -- examples, disabled
;
; These need the ipl-web patch; with the icingadb-web patch they are ignored.
; Checked against the current main branch, so verify the columns against your own
; version before enabling. To enable, remove the leading ';' from the section header
; and its three keys.
;
; Kubernetes controllers extend a shared ListController that fills getSortColumns(),
; so patching this module on its own is a one-place change if you prefer that over
; the ipl-web patch.
;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

; Model/Pod.php: namespace, name, node_name, ip, phase, icinga_state, restart_policy,
;                cpu_limits, cpu_requests, memory_limits, memory_requests, qos, created
;
;[kubernetes_pod_state]
;type  = "kubernetes/pods"
;sort  = "pod.icinga_state,pod.name"
;title = "State"
;
;[kubernetes_pod_memory_limits]
;type  = "kubernetes/pods"
;sort  = "pod.memory_limits desc"
;title = "Memory Limits"
;
;[kubernetes_pod_cpu_limits]
;type  = "kubernetes/pods"
;sort  = "pod.cpu_limits desc"
;title = "CPU Limits"

; Model/Deployment.php: namespace, name, desired_replicas, actual_replicas,
;                       ready_replicas, unavailable_replicas, icinga_state, created
;
;[kubernetes_deploy_unavailable]
;type  = "kubernetes/deployments"
;sort  = "deployment.unavailable_replicas desc,deployment.name"
;title = "Unavailable Replicas"
;
;[kubernetes_deploy_state]
;type  = "kubernetes/deployments"
;sort  = "deployment.icinga_state,deployment.name"
;title = "State"

; Model/Node.php: name, ready, unschedulable, cpu_capacity, memory_capacity,
;                 pod_capacity, kubelet_version, icinga_state, created
;
;[kubernetes_node_not_ready]
;type  = "kubernetes/nodes"
;sort  = "node.ready,node.name"
;title = "Not Ready First"
;
;[kubernetes_node_kubelet]
;type  = "kubernetes/nodes"
;sort  = "node.kubelet_version,node.name"
;title = "Kubelet Version"
