### PR TITLE
Preserve original `$_SERVER` headers in `CsrfCounterMeasureTest`

### DIFF
--- a/tests/Common/CsrfCounterMeasureTest.php
+++ b/tests/Common/CsrfCounterMeasureTest.php
@@ -15,16 +15,37 @@ use Psr\Http\Message\UriInterface;
 
 class CsrfCounterMeasureTest extends TestCase
 {
+    /** @var mixed Original SEC_FETCH_SITE value restored to avoid leaking global test state */
+    private mixed $secFetchSiteHeader;
+
+    /** @var mixed Original REQUEST_METHOD value restored to avoid leaking global test state */
+    private mixed $requestMethodHeader;
+
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->secFetchSiteHeader = $_SERVER['HTTP_SEC_FETCH_SITE'] ?? null;
+        $this->requestMethodHeader = $_SERVER['REQUEST_METHOD'] ?? null;
+
         unset($_SERVER['HTTP_SEC_FETCH_SITE'], $_SERVER['REQUEST_METHOD']);
     }
 
     protected function tearDown(): void
     {
+        if ($this->secFetchSiteHeader === null) {
+            unset($_SERVER['HTTP_SEC_FETCH_SITE']);
+        } else {
+            $_SERVER['HTTP_SEC_FETCH_SITE'] = $this->secFetchSiteHeader;
+        }
+
+        if ($this->requestMethodHeader === null) {
+            unset($_SERVER['REQUEST_METHOD']);
+        } else {
+            $_SERVER['REQUEST_METHOD'] = $this->requestMethodHeader;
+        }
+
         parent::tearDown();
-        unset($_SERVER['HTTP_SEC_FETCH_SITE'], $_SERVER['REQUEST_METHOD']);
     }
 
     public function testTokenCreation()


### PR DESCRIPTION
`CsrfCounterMeasureTest` manipulated the global `$_SERVER` superglobal to exercise the CSRF request-safety logic (`HTTP_SEC_FETCH_SITE`, `REQUEST_METHOD`). Its `tearDown()` unconditionally `unset()` these keys, discarding whatever values were present before the test ran. Any later test that relies on those values would observe a cleared global state it never set.

### Change

`setUp()` now captures the original values of `HTTP_SEC_FETCH_SITE` and `REQUEST_METHOD` before clearing them, and `tearDown()` restores them: unsetting only the keys that were absent originally, and reinstating the rest. The test suite no longer leaks mutations of these globals into other tests.